### PR TITLE
Enable cross-login with optional main account

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -9,10 +9,7 @@ security:
                 property: email
 
         client1_user_provider:
-            entity:
-                class: App\WhiteLabel\Entity\Client1\User
-                property: email
-                manager_name: client1
+            id: App\Security\Client1UserProvider
 
     firewalls:
         dev:

--- a/src/WhiteLabel/Form/Client1/RegistrationFormType.php
+++ b/src/WhiteLabel/Form/Client1/RegistrationFormType.php
@@ -57,6 +57,11 @@ class RegistrationFormType extends AbstractType
                     'label' => 'app_register.agree_terms',
                 ],
             ])
+            ->add('createOlonaAccount', CheckboxType::class, [
+                'label' => 'app_register.create_olona_account',
+                'mapped' => false,
+                'required' => false,
+            ])
             ->add('plainPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'invalid_message' => 'Les mots de passe ne correspondent pas.',

--- a/templates/white_label/client1/home/register.html.twig
+++ b/templates/white_label/client1/home/register.html.twig
@@ -112,6 +112,12 @@
                                         })|raw }}
                                     </label>
                             </div>
+                            <div class="form-check form-check-inline my-2">
+                                {{ form_widget(registrationForm.createOlonaAccount) }}
+                                <label class="form-check-label" for="{{ registrationForm.createOlonaAccount.vars.id }}">
+                                    {{ 'app_register.create_olona_account'|trans }}
+                                </label>
+                            </div>
                             <div class="text-center my-3">
                                 <button class="btn btn-login" type="submit" id="register-submit">
                                     {{ 'app_register.menu'|trans }}                

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -378,6 +378,7 @@ app_register:
     repeat_password: "Repeter le mot de passe"
     agree_terms: "<small class='ml-3 pt-sans'>En vous inscrivant, vous acceptez nos <a class=\"fw-bolder\" href=\"%terms_url%\">Conditions Générales d'Utilisation</a> et notre <a href=\"%privacy_url%\" class=\"fw-bolder\">Politique de Confidentialité</a>.</small>"
     continue: "Continuer avec "
+    create_olona_account: "Créer également un compte sur olona-talents.com"
 
 app_email_sending:
     title: "Email de confirmation envoyé"


### PR DESCRIPTION
## Summary
- implement a custom user provider that can read users from both the white‑label and the main entity managers
- allow registering for the white‑label site while optionally creating an Olona Talents account
- expose checkbox in the registration form and template
- register the new provider in security config
- update French translations

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a854157608330a62ae378a56d0d3b