### PR TITLE
Improve host redirection for white label login

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ parameters:
     cv_expert: /uploads/experts
     medias_prestation: /uploads/prestations
     logo_company: /uploads/compagnies
+    white_label.client1.host: 'client1.olona-talents.com'
     app.locales: [en, fr]
     cv_directory: '%kernel.project_dir%/public/uploads/cv'
     csv_directory: '%kernel.project_dir%/public/uploads/csv'
@@ -73,7 +74,7 @@ services:
 
     App\EventListener\RedirectToHomeListener:
         arguments:
-            $targetHost: 'client1.olona-talents.com'
+            $targetHost: '%white_label.client1.host%'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
@@ -107,6 +108,10 @@ services:
         public: true
         tags:
             - { name: security.request_matcher }
+
+    App\Security\AppAuthenticator:
+        arguments:
+            $client1Host: '%white_label.client1.host%'
 
     app.sitemap.blog_post_subscriber:
         class: App\EventListener\SitemapSubscriber

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -39,7 +39,7 @@ class SecurityController extends AbstractController
 
         $error = $authenticationUtils->getLastAuthenticationError();
         $lastUsername = $authenticationUtils->getLastUsername();
-        $wlRedirect = $request->query->get('wl');
+        $wlRedirect = $request->query->get('wl', 'client1');
 
         return $this->render('security/login.html.twig', [
             'last_username' => $lastUsername, 

--- a/src/Security/AppAuthenticator.php
+++ b/src/Security/AppAuthenticator.php
@@ -29,11 +29,12 @@ class AppAuthenticator extends AbstractLoginFormAuthenticator
     public const LOGIN_ROUTE = 'app_login';
 
     public function __construct(
-        private UrlGeneratorInterface $urlGenerator, 
+        private UrlGeneratorInterface $urlGenerator,
         private UserPostAuthenticationService $userPostAuthenticationService,
         private ActivityLogger $activityLogger,
         private UserService $userService,
         private ManagerRegistry $registry,
+        private string $client1Host,
     ){}
 
     public function authenticate(Request $request): Passport
@@ -78,7 +79,9 @@ class AppAuthenticator extends AbstractLoginFormAuthenticator
                 $emClient1->flush();
             }
 
-            return new RedirectResponse($this->urlGenerator->generate('app_white_label_home'));
+            $url = $this->urlGenerator->generate('app_white_label_home', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            $url = preg_replace('#://[^/]+#', '://'.$this->client1Host, $url);
+            return new RedirectResponse($url);
         }
         if ($routeName === 'coworking_login') {
             return new RedirectResponse($this->urlGenerator->generate('app_coworking_main'));


### PR DESCRIPTION
## Summary
- define `white_label.client1.host` parameter
- inject host in `AppAuthenticator`
- redirect to client1 domain after login
- default `wl` query to `client1`

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bce21251083309f4469f0cae71c7d