### PR TITLE
Implement temporary SSO token flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # Olona Talents
 
-# To init project run this command
-# php bin/console app:init-project
+## Project initialization
+Run:
+```
+php bin/console app:init-project
+```
 
-# To create moderateur run this command with two arguments <email> and <password>
-# php bin/console app:create-moderateur <email> <password>
+## Create a moderator
+Run:
+```
+php bin/console app:create-moderateur <email> <password>
+```
+
+## Temporary SSO flow
+1. Users authenticate on `olona-talents.com`.
+2. After login, the server generates a temporary token and redirects to the white label domain:
+   `https://client1.olona-talents.com/consume-token?token=XYZ123`.
+3. The client domain requests `/api/sso/verify-token` with the token to retrieve user info.
+4. With the returned data, the user session is created on `client1`.

--- a/src/Controller/SsoController.php
+++ b/src/Controller/SsoController.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Controller;
+
+use App\Service\SsoTokenService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class SsoController extends AbstractController
+{
+    #[Route('/api/sso/verify-token', name: 'api_sso_verify_token', methods: ['GET'])]
+    public function verifyToken(Request $request, SsoTokenService $service): JsonResponse
+    {
+        $token = $request->query->get('token');
+        if (!$token) {
+            return $this->json(['error' => 'Token missing'], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $user = $service->consumeToken($token);
+        if (!$user) {
+            return $this->json(['error' => 'Invalid token'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        return $this->json([
+            'email' => $user->getEmail(),
+            'roles' => $user->getRoles(),
+        ]);
+    }
+}

--- a/src/Entity/SsoToken.php
+++ b/src/Entity/SsoToken.php
@@ -1,0 +1,56 @@
+<?php
+namespace App\Entity;
+
+use App\Repository\SsoTokenRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity(repositoryClass: SsoTokenRepository::class)]
+class SsoToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'string', length: 36)]
+    private string $token;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $consumedAt = null;
+
+    public function __construct(User $user, int $ttlSeconds = 300)
+    {
+        $this->token = Uuid::v4()->toRfc4122();
+        $this->user = $user;
+        $this->expiresAt = new \DateTimeImmutable('+' . $ttlSeconds . ' seconds');
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expiresAt < new \DateTimeImmutable();
+    }
+
+    public function isConsumed(): bool
+    {
+        return $this->consumedAt !== null;
+    }
+
+    public function consume(): void
+    {
+        $this->consumedAt = new \DateTimeImmutable();
+    }
+}

--- a/src/Repository/SsoTokenRepository.php
+++ b/src/Repository/SsoTokenRepository.php
@@ -1,0 +1,45 @@
+<?php
+namespace App\Repository;
+
+use App\Entity\SsoToken;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<SsoToken>
+ */
+class SsoTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SsoToken::class);
+    }
+
+    public function save(SsoToken $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(SsoToken $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function consumeValidToken(string $token): ?SsoToken
+    {
+        /** @var SsoToken|null $ssoToken */
+        $ssoToken = $this->find($token);
+        if (!$ssoToken || $ssoToken->isExpired() || $ssoToken->isConsumed()) {
+            return null;
+        }
+        $ssoToken->consume();
+        $this->getEntityManager()->flush();
+        return $ssoToken;
+    }
+}

--- a/src/Service/SsoTokenService.php
+++ b/src/Service/SsoTokenService.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Service;
+
+use App\Entity\SsoToken;
+use App\Entity\User;
+use App\Repository\SsoTokenRepository;
+
+class SsoTokenService
+{
+    public function __construct(private SsoTokenRepository $repository)
+    {
+    }
+
+    public function createToken(User $user, int $ttlSeconds = 300): SsoToken
+    {
+        $token = new SsoToken($user, $ttlSeconds);
+        $this->repository->save($token, true);
+        return $token;
+    }
+
+    public function consumeToken(string $token): ?User
+    {
+        $ssoToken = $this->repository->consumeValidToken($token);
+        return $ssoToken?->getUser();
+    }
+}

--- a/src/WhiteLabel/Controller/Client1/SecurityController.php
+++ b/src/WhiteLabel/Controller/Client1/SecurityController.php
@@ -4,10 +4,14 @@ namespace App\WhiteLabel\Controller\Client1;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use App\Security\Client1\Client1Authenticator;
 
 class SecurityController extends AbstractController
 {
@@ -38,5 +42,41 @@ class SecurityController extends AbstractController
     public function logout(): void
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
+    }
+
+    #[Route('/consume-token', name: 'app_client1_consume_token')]
+    public function consumeToken(
+        Request $request,
+        HttpClientInterface $httpClient,
+        UserAuthenticatorInterface $userAuthenticator,
+        Client1Authenticator $authenticator,
+    ): Response {
+        $token = $request->query->get('token');
+        if (!$token) {
+            return $this->redirectToRoute('app_client1_login');
+        }
+
+        $response = $httpClient->request('GET', 'https://olona-talents.com/api/sso/verify-token', [
+            'query' => ['token' => $token],
+        ]);
+
+        if (200 !== $response->getStatusCode()) {
+            return $this->redirectToRoute('app_client1_login');
+        }
+
+        $data = $response->toArray();
+        $user = $this->entityManager->getRepository(\App\WhiteLabel\Entity\Client1\User::class)->findOneBy(['email' => $data['email']]);
+        if (!$user) {
+            $user = $this->entityManager->getRepository(\App\Entity\User::class)->findOneBy(['email' => $data['email']]);
+        }
+        if (!$user) {
+            return $this->redirectToRoute('app_client1_login');
+        }
+
+        return $userAuthenticator->authenticateUser(
+            $user,
+            $authenticator,
+            $request
+        );
     }
 }


### PR DESCRIPTION
## Summary
- document initialization and SSO flow in README
- implement `SsoToken` entity and repository
- add `SsoTokenService` to handle create/consume token
- expose `/api/sso/verify-token` endpoint
- allow client1 site to consume token and authenticate user

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc742e97c8330b0263a49af2959c8