### PR TITLE
Add employee interface in white label

### DIFF
--- a/src/WhiteLabel/Controller/Client1/EmployeController.php
+++ b/src/WhiteLabel/Controller/Client1/EmployeController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\WhiteLabel\Controller\Client1;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_EMPLOYE')]
+#[Route('/employe')]
+class EmployeController extends AbstractController
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private EntityManagerInterface $entityManager,
+    ) {
+        $this->entityManager = $managerRegistry->getManager('client1');
+    }
+
+    #[Route('/', name: 'app_white_label_client1_employe')]
+    public function index(): Response
+    {
+        return $this->render('white_label/client1/employe/index.html.twig');
+    }
+
+    #[Route('/mes-infos', name: 'app_white_label_client1_employe_profile')]
+    public function profile(): Response
+    {
+        return $this->render('white_label/client1/employe/profile.html.twig');
+    }
+}

--- a/src/WhiteLabel/Controller/Client1/HomeController.php
+++ b/src/WhiteLabel/Controller/Client1/HomeController.php
@@ -33,7 +33,8 @@ class HomeController extends AbstractController
         return match (true) {
             $security->isGranted('ROLE_ADMIN')     => $this->redirectToRoute('app_white_label_client1_admin'),
             $security->isGranted('ROLE_RECRUITER') => $this->redirectToRoute('app_white_label_client1_recruiter'),
-            $security->isGranted('ROLE_CANDIDAT') => $this->redirectToRoute('app_white_label_client1_user'),
+            $security->isGranted('ROLE_EMPLOYE')   => $this->redirectToRoute('app_white_label_client1_employe'),
+            $security->isGranted('ROLE_CANDIDAT')  => $this->redirectToRoute('app_white_label_client1_user'),
             default => $this->render('white_label/client1/home/home.html.twig', [
                 'job_offers' => $this->entityManager->getRepository(JobListing::class)->findBy(
                     ['status' => JobListing::STATUS_PUBLISHED],

--- a/templates/white_label/client1/employe/index.html.twig
+++ b/templates/white_label/client1/employe/index.html.twig
@@ -1,0 +1,9 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Espace employé{% endblock %}
+
+{% block body %}
+<div class="example-wrapper">
+    <h1>Hello {{ app.user.prenom }}!</h1>
+</div>
+{% endblock %}

--- a/templates/white_label/client1/employe/profile.html.twig
+++ b/templates/white_label/client1/employe/profile.html.twig
@@ -1,0 +1,9 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Mes infos{% endblock %}
+
+{% block body %}
+<div class="example-wrapper">
+    <h1>Mes infos</h1>
+</div>
+{% endblock %}

--- a/templates/white_label/client1/layout/sidebar.html.twig
+++ b/templates/white_label/client1/layout/sidebar.html.twig
@@ -19,7 +19,18 @@
         </a>
       </li>
 
-    {% if is_granted('ROLE_CANDIDAT') %}
+    {% if is_granted('ROLE_EMPLOYE') %}
+      <li class="nav-item">
+        <a href="{{ path('app_white_label_client1_employe') }}" class="nav-link {{ current_route == 'app_white_label_client1_employe' ? 'underline' : '' }}" aria-current="page">
+        <img src="{{ asset('v2/images/dashboard/dashboard.svg')}}" alt=""><span class="sidebar-text">Espace employé</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{{ path('app_white_label_client1_employe_profile')}}" class="nav-link {{ current_route == 'app_white_label_client1_employe_profile' ? 'underline' : '' }}" aria-current="page">
+        <img src="{{ asset('v2/images/dashboard/profil.svg')}}" alt=""><span class="sidebar-text">Mes infos</span>
+        </a>
+      </li>
+    {% elseif is_granted('ROLE_CANDIDAT') %}
       <li class="nav-item">
         <a href="{{ path('app_white_label_client1_user_missions')}}" class="nav-link {{ (current_route == 'app_white_label_client1_user_missions' or current_route == 'app_tableau_de_bord_candidat_view_job_offer' or current_route == 'app_olona_talents_prestations') ? 'underline' : '' }}" aria-current="page">
         <img src="{{ asset('v2/images/dashboard/missions.svg')}}" alt=""><span class="sidebar-text">Trouver des missions</span>


### PR DESCRIPTION
## Summary
- add employee dashboard controller with index and profile pages
- redirect employees to the new interface on login
- update sidebar to display employee links

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c13bc3b883308dafbd4016b6d559