### PR TITLE
Implement white label assistance form

### DIFF
--- a/src/WhiteLabel/Entity/Client1/ContactForm.php
+++ b/src/WhiteLabel/Entity/Client1/ContactForm.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\WhiteLabel\Entity\Client1;
+
+use App\WhiteLabel\Repository\Client1\ContactFormRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: ContactFormRepository::class)]
+class ContactForm
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $titre = null;
+
+    #[ORM\Column(type: Types::TEXT)]
+    private ?string $message = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    private ?\DateTimeInterface $createdAt = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $email = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $numero = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitre(): ?string
+    {
+        return $this->titre;
+    }
+
+    public function setTitre(string $titre): static
+    {
+        $this->titre = $titre;
+        return $this;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(string $message): static
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): static
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getNumero(): ?string
+    {
+        return $this->numero;
+    }
+
+    public function setNumero(?string $numero): static
+    {
+        $this->numero = $numero;
+        return $this;
+    }
+}

--- a/src/WhiteLabel/Form/Client1/AssistanceType.php
+++ b/src/WhiteLabel/Form/Client1/AssistanceType.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1;
+
+use App\Service\User\UserService;
+use App\WhiteLabel\Entity\Client1\ContactForm;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Sequentially;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AssistanceType extends AbstractType
+{
+    public function __construct(private UserService $userService)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('titre', TextType::class, [
+                'label' => 'Titre',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-6'
+                ],
+                'attr' => [
+                    'placeholder' => 'Objet de votre demande'
+                ],
+                'help' => 'Veuillez préciser l\'objet de votre demande en quelques mots.',
+            ])
+            ->add('email', EmailType::class, [
+                'label' => 'Votre adresse email *',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-6'
+                ],
+                'attr' => [
+                    'value' => $this->userService->getCurrentUser() ? $this->userService->getCurrentUser()->getEmail() : ''
+                ],
+                'help' => 'Nous utiliserons cette adresse pour vous recontacter.',
+            ])
+            ->add('message', TextareaType::class, [
+                'required' => false,
+                'label' => 'Message *',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-6'
+                ],
+                'constraints' => new Sequentially([
+                    new NotBlank(message: 'Le message est obligatoire.'),
+                    new Length(min: 3, minMessage: 'Le message est trop court'),
+                ]),
+                'attr' => [
+                    'rows' => 6,
+                    'class' => 'ckeditor-textarea'
+                ],
+                'help' => 'Décrivez votre problème ou posez votre question ici...',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ContactForm::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Repository/Client1/ContactFormRepository.php
+++ b/src/WhiteLabel/Repository/Client1/ContactFormRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\WhiteLabel\Repository\Client1;
+
+use App\WhiteLabel\Entity\Client1\ContactForm;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ContactForm>
+ *
+ * @method ContactForm|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ContactForm|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ContactForm[]    findAll()
+ * @method ContactForm[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ContactFormRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ContactForm::class);
+    }
+
+    public function findLatestReservationByUniqueEmail()
+    {
+        $subQuery = $this->createQueryBuilder('sub')
+            ->select('MAX(sub.id)')
+            ->groupBy('sub.email');
+
+        return $this->createQueryBuilder('c')
+            ->select('c')
+            ->where('c.id IN (' . $subQuery->getDQL() . ')')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/templates/white_label/client1/user/assistance.html.twig
+++ b/templates/white_label/client1/user/assistance.html.twig
@@ -3,5 +3,15 @@
 {% block title %}Assistance{% endblock %}
 
 {% block body %}
-
+<div class="biographie-profil mb-4 p-4 besoin_assitacne">
+    <h2> Besoin d'assistance ? <br/> Dites-nous en plus sur vos besoins ! </h2>
+    {{ form_start(form) }}
+    {{ form_row(form.titre) }}
+    {{ form_row(form.message) }}
+    <div style="display:none;">
+        {{ form_widget(form) }}
+    </div>
+    <button type="submit" class="btn btn-primary">Envoyer</button>
+    {{ form_end(form) }}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new ContactForm entity and repository for white label client
- create AssistanceType form for client1
- build user assistance action and template

## Testing
- `./bin/phpunit -q` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855a679ed2c8330bc83cbdc97acafb5