### PR TITLE
Add white label user profile page

### DIFF
--- a/src/WhiteLabel/Form/Client1/Candidat/TarifCandidatType.php
+++ b/src/WhiteLabel/Form/Client1/Candidat/TarifCandidatType.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Candidat;
+
+use App\WhiteLabel\Entity\Client1\Finance\Devise;
+use App\WhiteLabel\Entity\Client1\Candidate\TarifCandidat;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Sequentially;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+
+class TarifCandidatType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('montant', IntegerType::class, [
+                'required' => false,
+                'label' => 'Montant',
+                'constraints' => new Sequentially([
+                    new NotBlank(message:'Champ obligatoire.'),
+                ]),
+                'row_attr' => ['class' => 'col-md-6'],
+            ])
+            ->add('typeTarif', ChoiceType::class, [
+                'choices' => TarifCandidat::arrayTarifType(),
+                'label' => 'Type',
+                'row_attr' => ['class' => 'col-md-6'],
+            ])
+            ->add('currency', EntityType::class, [
+                'label' => 'Devise',
+                'mapped' => true,
+                'class' => Devise::class, 
+                'attr' => [
+                    'data-controller' => 'tarif-devise',
+                    'data-action' => 'change->tarif-devise#onDeviseChange'
+                ],
+                'row_attr' => ['class' => 'col-md-6'],
+            ])   
+            ->add('devise', HiddenType::class, [
+                'attr' =>  [
+                    'data-id' => 'tarif_symbole',
+                ],
+                'data' => '€',  
+                'required' => true,
+                'empty_data' => '€', 
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => TarifCandidat::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/ContactType.php
+++ b/src/WhiteLabel/Form/Client1/ContactType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1;
+
+use App\WhiteLabel\Entity\Client1\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContactType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class, [
+                'label' => 'Adresse éléctronique (*)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Veuillez entrer une adresse e-mail valide. Exemple : contact@exemple.com.',
+            ])
+            ->add('telephone', TextType::class, [
+                'label' => 'Téléphone (*)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Entrez un numéro de téléphone valide avec l\'indicatif international si nécessaire.',
+            ])
+            ->add('adress', TextType::class, [
+                'label' => 'Adresse (*)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Indiquez l’adresse postale complète de votre entreprise.',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/EditEntrepriseType.php
+++ b/src/WhiteLabel/Form/Client1/EditEntrepriseType.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1;
+
+use App\WhiteLabel\Entity\Client1\Secteur;
+use App\WhiteLabel\Form\Client1\ContactType;
+use App\WhiteLabel\Entity\Client1\Finance\Devise;
+use App\WhiteLabel\Entity\Client1\EntrepriseProfile;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class EditEntrepriseType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('file', FileType::class, [
+                'required' => false,
+                'label' => 'Votre logo',
+                'attr' => ['class' => 'd-none'],
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Uploader votre logo de l\'entreprise.',
+                'constraints' => [
+                    new File([
+                        'maxSize' => '2048k',
+                        'mimeTypes' => [
+                            'image/jpeg',
+                            'image/png',
+                            'image/jpg',
+                            'image/bmp',
+                        ],
+                    ])
+                ],
+            ])
+            ->add('devise', EntityType::class, [
+                'class' => Devise::class,
+                'label' => 'Séléctionner votre devise',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Choisissez la devise que vous utilisez pour les transactions.',
+            ])
+            ->add('nom', TextType::class, [
+                'label' => 'Raison sociale (*)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Indiquez la raison sociale complète de votre entreprise.',
+            ])
+            ->add('taille', ChoiceType::class, [
+                'choices' => EntrepriseProfile::CHOICE_SIZE,
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Sélectionnez la taille approximative de votre entreprise.',
+            ])
+            ->add('description', TextareaType::class, [
+                'required' => false,
+                'label' => 'Description (*)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Décrivez brièvement votre entreprise et ses activités.',
+                'attr' => [
+                    'rows' => 6,
+                    'class' => 'ckeditor-textarea'
+                ]
+            ])
+            ->add('secteurs', EntityType::class, [
+                    'class' => Secteur::class,
+                    'choice_label' => 'nom',
+                    'label_attr' => [
+                        'class' => 'fw-bold fs-5' 
+                    ],
+                    'label' => 'Secteur(s) d\'expertise (*)',
+                    'autocomplete' => true,
+                    'multiple' => true,
+                    'help' => 'Sélectionnez un ou plusieurs secteurs dans lesquels votre entreprise est active.',
+            ])
+            ->add('siteWeb', TextType::class, [
+                'label' => 'Site Internet (facultatif)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Entrez l\'URL complète de votre site web (ex: https://www.monsite.com).',
+            ])
+            ->add('entreprise', ContactType::class, [
+                'label' => false,
+            ])
+            ->add('localisation', CountryType::class, [
+                'label' => 'Pays (*)',
+                'label_attr' => [
+                    'class' => 'fw-bold fs-5' 
+                ],
+                'help' => 'Sélectionnez le pays où est située votre entreprise.',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => EntrepriseProfile::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Finance/AvantageType.php
+++ b/src/WhiteLabel/Form/Client1/Finance/AvantageType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Finance;
+
+use App\WhiteLabel\Entity\Client1\Finance\Avantage;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AvantageType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('absence')
+            ->add('hs30', NumberType::class, ['label' => 'HS 30% heures nuit habituelles', 'required' => false])
+            ->add('hs40', NumberType::class, ['label' => 'HS 40% heures travaillées dimanche', 'required' => false])
+            ->add('hs50', NumberType::class, ['label' => 'HS 50% heures nuit occasionnelles', 'required' => false])
+            ->add('hs130', NumberType::class, ['label' => 'HS 30% heures jour (8 première) ', 'required' => false])
+            ->add('hs150', NumberType::class, ['label' => 'HS 50% heures jour (restantes)', 'required' => false])
+            ->add('hn', NumberType::class, ['label' => 'HS 100% jours fériers', 'required' => false])
+            ->add('congePaye')
+            ->add('congePris')
+            ->add('primeFonction')
+            ->add('primeConnexion')
+            ->add('rappel')
+            ->add('repas')
+            ->add('deplacement')
+            ->add('allocationConge')
+            ->add('preavis')
+            ->add('primeAvance15')
+            ->add('avanceSpeciale')
+            ->add('choixDeduction')
+            ->add('salaireBrut')
+            ->add('moySur12')
+            ->add('freelance')
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Avantage::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Finance/EmployeType.php
+++ b/src/WhiteLabel/Form/Client1/Finance/EmployeType.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Finance;
+
+use App\WhiteLabel\Entity\Client1\User;
+use App\WhiteLabel\Entity\Client1\Finance\Employe;
+use Symfony\Component\Form\AbstractType;
+use App\WhiteLabel\Form\Client1\Profile\Candidat\Edit\InfoUserType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
+class EmployeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('user', InfoUserType::class, ['label' => false])
+            ->add('dateEmbauche', DateType::class, [
+                'widget' => 'single_text',  
+            ])
+            ->add('nombreEnfants')
+            ->add('matricule')
+            ->add('cnaps')
+            ->add('sexe', ChoiceType::class, [
+                'choices' => [
+                    'Masculin' => 0,
+                    'Féminin' => 1,
+                ],
+            ])
+            ->add('cin')
+            ->add('dateNaissance', DateType::class, [
+                'widget' => 'single_text',  
+            ])
+            ->add('categorie')
+            ->add('fonction')
+            ->add('salaireBase')
+            ->add('congePris')
+            ->add('avantage', AvantageType::class, [
+                'label' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Employe::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Profile/Candidat/CompetencesType.php
+++ b/src/WhiteLabel/Form/Client1/Profile/Candidat/CompetencesType.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Profile\Candidat;
+
+use App\WhiteLabel\Entity\Client1\Candidate\Competences;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class CompetencesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('nom', TextType::class, [
+                'label' => 'Compétence',
+                'required' => false,
+            ])
+            ->add('note', ChoiceType::class, [
+                'label' => 'Niveau',
+                'required' => true,
+                'choices'  => [
+                    'app_identity_expert_step_two.skill.one' => 1,
+                    'app_identity_expert_step_two.skill.two' => 2,
+                    'app_identity_expert_step_two.skill.three' => 3,
+                    'app_identity_expert_step_two.skill.four' => 4,
+                    'app_identity_expert_step_two.skill.five' => 5,
+                ],
+                'expanded' => false,
+                'multiple' => false,
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'app_identity_expert_step_two.experience.description',
+                'required' => false,
+                'attr' => [
+                    'rows' => 6,
+                    'class' => 'ckeditor-textarea'
+                ]
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Competences::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Profile/Candidat/Edit/EditCandidateProfile.php
+++ b/src/WhiteLabel/Form/Client1/Profile/Candidat/Edit/EditCandidateProfile.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Profile\Candidat\Edit;
+
+use App\WhiteLabel\Entity\Client1\Secteur;
+use App\WhiteLabel\Entity\Client1\CandidateProfile;
+use App\WhiteLabel\Form\Client1\Candidat\TarifCandidatType;
+use Symfony\Component\Form\AbstractType;
+use App\WhiteLabel\Form\Client1\Profile\Candidat\SocialType;
+use App\WhiteLabel\Form\Client1\Profile\Candidat\LangagesType;
+use App\WhiteLabel\Form\Client1\Profile\Candidat\CompetencesType;
+use App\WhiteLabel\Form\Client1\Profile\Candidat\ExperiencesType;
+use App\WhiteLabel\Form\Client1\Profile\Candidat\Edit\InfoUserType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+
+class EditCandidateProfile extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('file', FileType::class, [
+                'required' => false,
+                'label' => 'app_identity_expert_step_one.avatar',
+                'attr' => ['class' => 'd-none'],
+                'constraints' => [
+                    new File([
+                        'maxSize' => '2048k',
+                        'mimeTypes' => [
+                            'image/jpeg',
+                            'image/png',
+                            'image/jpg',
+                            'image/bmp',
+                        ],
+                    ])
+                ],
+            ])
+            ->add('candidat', InfoUserType::class, ['label' => false])
+            ->add('localisation', CountryType::class, [
+                'required' => true,
+                'label' => 'Pays',
+                'attr' => ['class' => 'd-none'],
+            ])
+            ->add('birthday', DateType::class, [
+                'label' => 'Votre anniversaire',
+                'years' => range(1970, 2010),
+                'attr' => ['class' => 'rounded-pill'] 
+            ])
+            ->add('resume', TextareaType::class, [
+                'label' => 'app_identity_expert.aspiration',
+                'required' => false,
+                'attr' => [
+                    'rows' => 6,
+                    'class' => 'ckeditor-textarea'
+                ]
+            ])
+            ->add('titre', TextType::class, [
+                'required' => false,
+                'label' => 'app_identity_expert.name',
+            ])
+            ->add('tarifCandidat', TarifCandidatType::class, [
+                'required' => false,
+                'label' => 'Prétention salariale',
+            ])
+            ->add('social', SocialType::class, ['label' => false])
+            ->add('secteurs', EntityType::class, [
+                'class' => Secteur::class,
+                'label' => 'app_identity_company.sector_multiple',
+                'choice_label' => 'nom',
+                'autocomplete' => true,
+                'multiple' => true,
+                'required' => true,
+            ])
+            ->add('competences', CollectionType::class, [
+                'entry_type' => CompetencesType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'entry_options' => ['label' => false],
+                'attr' => [
+                    'data-controller' => 'form-collection',
+                    'data-form-collection-add-label-value' => 'Ajouter une compétence',
+                    'data-form-collection-delete-label-value' => 'Supprimer'
+                ]
+            ])
+            ->add('experiences', CollectionType::class, [
+                'entry_type' => ExperiencesType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'entry_options' => ['label' => false],
+                'attr' => [
+                    'data-controller' => 'form-collection',
+                    'data-form-collection-add-label-value' => 'Ajouter une expérience',
+                    'data-form-collection-delete-label-value' => 'Supprimer'
+                ]
+            ])
+            ->add('langages', CollectionType::class, [
+                'entry_type' => LangagesType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'entry_options' => ['label' => false],
+                'attr' => [
+                    'data-controller' => 'form-collection',
+                    'data-form-collection-add-label-value' => 'Ajouter une langue',
+                    'data-form-collection-delete-label-value' => 'Supprimer',
+                ]
+            ])
+            ->add('cv', FileType::class, [
+                'label' => 'Ajouter un CV',
+                'label_attr' => ['class' => 'col-form-label'],
+                'mapped' => false,
+                'required' => false,
+                'attr' => ['class' => 'custom-file-input'],
+                'constraints' => [
+                    new File([
+                        'maxSize' => '4096k',
+                        'mimeTypes' => [
+                            'application/pdf',
+                            'application/x-pdf',
+                        ],
+                        'mimeTypesMessage' => 'Veuillez télécharger un document PDF valide.',
+                    ])
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => CandidateProfile::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Profile/Candidat/Edit/InfoUserType.php
+++ b/src/WhiteLabel/Form/Client1/Profile/Candidat/Edit/InfoUserType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Profile\Candidat\Edit;
+
+use App\WhiteLabel\Entity\Client1\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+
+class InfoUserType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('nom', TextType::class, [
+                'label' => 'app_identity_expert_step_one.user.firstName',
+            ])
+            ->add('prenom', TextType::class, [
+                'label' => 'app_identity_expert_step_one.user.lastName',
+            ])
+            ->add('telephone', TextType::class, [
+                'label' => 'app_identity_company.phone',
+                'required' => true,
+            ])
+            ->add('adress', TextType::class, [
+                'label' => 'Adresse',
+                'required' => true,
+            ])
+            ->add('city', TextType::class, [
+                'label' => 'Ville *',
+                'required' => true,
+            ])
+            ->add('email', EmailType::class, [
+                'label' => 'app_identity_company.email',
+                'required' => true,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Profile/Candidat/ExperiencesType.php
+++ b/src/WhiteLabel/Form/Client1/Profile/Candidat/ExperiencesType.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Profile\Candidat;
+
+use App\WhiteLabel\Entity\Client1\Candidate\Experiences;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class ExperiencesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('nom', TextType::class, [
+                'label' => 'app_identity_expert_step_two.experience.title',
+                'attr' => ['class' => 'form-control experience-field', 'style' => 'width: 100%']
+            ])
+            ->add('entreprise', TextType::class, [
+                'label' => 'app_identity_expert_step_two.experience.company',
+                'attr' => ['class' => 'form-control experience-field', 'style' => 'width: 100%']
+            ])
+            ->add('enPoste', CheckboxType::class, [
+                'label' => 'app_identity_expert_step_two.experience.currently',
+                'required' => false,
+                'attr' => ['data-form-collection-target' => 'currentlyCheckbox', 'class' => 'form-check-input']
+            ])
+            ->add('dateDebut', DateType::class, [
+                'label' => 'Date de début',
+                'attr' => [
+                    'class' => 'form-control experience-field', 
+                    'style' => 'width: 50%'
+                ],
+                'widget' => 'single_text',  
+                'format' => 'yyyy-MM-dd', 
+            ])
+            ->add('dateFin', DateType::class, [
+                'label' => 'Date fin',
+                'attr' => [
+                    'class' => 'form-control experience-field',
+                    'data-form-collection-target' => 'endDate',
+                    'style' => 'width: 50%'
+                ],
+                'widget' => 'single_text',  
+                'format' => 'yyyy-MM-dd', 
+                'required' => false,
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'app_identity_expert_step_two.experience.description',
+                'required' => false,
+                'attr' => [
+                    'rows' => 6,
+                    'class' => 'ckeditor-textarea form-control',
+                    'style' => 'width: 100%'
+                ]
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Experiences::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Profile/Candidat/LangagesType.php
+++ b/src/WhiteLabel/Form/Client1/Profile/Candidat/LangagesType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Profile\Candidat;
+
+use App\WhiteLabel\Entity\Client1\Langue;
+use App\WhiteLabel\Entity\Client1\Candidate\Langages;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+class LangagesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('langue', EntityType::class, [
+                'class' => Langue::class,
+                'label' => 'Langue',
+            ])
+            ->add('niveau', ChoiceType::class, [
+                'label' => 'Niveau',
+                'choices'  => [
+                    'app_identity_expert_step_two.skill.one' => 1,
+                    'app_identity_expert_step_two.skill.two' => 2,
+                    'app_identity_expert_step_two.skill.three' => 3,
+                    'app_identity_expert_step_two.skill.four' => 4,
+                    'app_identity_expert_step_two.skill.five' => 5,
+                ],
+                'expanded' => false,
+                'multiple' => false,
+                'required' => true,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Langages::class,
+            'langues_non_choisies' => null,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/Profile/Candidat/SocialType.php
+++ b/src/WhiteLabel/Form/Client1/Profile/Candidat/SocialType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Profile\Candidat;
+
+use App\WhiteLabel\Entity\Client1\Candidate\Social;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class SocialType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('linkedin', TextType::class, [
+                'required' => false,
+            ])
+            ->add('skype', TextType::class, [
+                'required' => false,
+            ])
+            ->add('slack', TextType::class, [
+                'required' => false,
+            ])
+            ->add('facebook', TextType::class, [
+                'required' => false,
+            ])
+            ->add('instagram', TextType::class, [
+                'required' => false,
+            ])
+            ->add('github', TextType::class, [
+                'required' => false,
+                'label' => 'Autre',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Social::class,
+        ]);
+    }
+}

--- a/templates/white_label/client1/user/profile.html.twig
+++ b/templates/white_label/client1/user/profile.html.twig
@@ -3,12 +3,21 @@
 {% block title %}Mes infos{% endblock %}
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
+<div class="container my-4">
+    {% if form is defined %}
+        {{ form_start(form, {'attr': {'data-turbo': 'false'}}) }}
+        {{ form_widget(form) }}
+        <button class="btn btn-primary mt-3">Sauvegarder</button>
+        {{ form_end(form) }}
+    {% endif %}
 
-<div class="example-wrapper">
-    <h1>Mes infos</h1>
+    {% if employeForm is defined %}
+        <hr/>
+        <h2>Employé</h2>
+        {{ form_start(employeForm, {'attr': {'data-turbo': 'false'}}) }}
+        {{ form_widget(employeForm) }}
+        <button class="btn btn-primary mt-3">Sauvegarder</button>
+        {{ form_end(employeForm) }}
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement user profile route to handle candidate, entreprise and employe forms
- create forms for white label candidate, entreprise and employe profiles
- render corresponding forms in the user profile template

## Testing
- `php` not available, could not run unit tests

------
https://chatgpt.com/codex/tasks/task_e_6855ab2087a08330a3063ee0728c9378