### PR TITLE
Uniformize white label pages

### DIFF
--- a/templates/white_label/client1/admin/annonces.html.twig
+++ b/templates/white_label/client1/admin/annonces.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Toutes les annonces{% endblock %}
+{% block page_title %}Toutes les annonces{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/candidat/edit.html.twig
+++ b/templates/white_label/client1/admin/candidat/edit.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modifier candidat{% endblock %}
+{% block page_title %}Modifier candidat{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/candidat/index.html.twig
+++ b/templates/white_label/client1/admin/candidat/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tous les candidats{% endblock %}
+{% block page_title %}Tous les candidats{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/candidat/new.html.twig
+++ b/templates/white_label/client1/admin/candidat/new.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Nouveau recruteur{% endblock %}
+{% block page_title %}Nouveau recruteur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/candidat/show.html.twig
+++ b/templates/white_label/client1/admin/candidat/show.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Candidat{% endblock %}
+{% block page_title %}Candidat{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/candidature/edit.html.twig
+++ b/templates/white_label/client1/admin/candidature/edit.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modifier utilisateur{% endblock %}
+{% block page_title %}Modifier utilisateur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/candidature/index.html.twig
+++ b/templates/white_label/client1/admin/candidature/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tous les candidatures{% endblock %}
+{% block page_title %}Tous les candidatures{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/candidature/new.html.twig
+++ b/templates/white_label/client1/admin/candidature/new.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Nouveau candidature{% endblock %}
+{% block page_title %}Nouveau candidature{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/candidature/show.html.twig
+++ b/templates/white_label/client1/admin/candidature/show.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Candidature #{{ application.id }}{% endblock %}
+{% block page_title %}Candidature #{{ application.id }}{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/candidatures.html.twig
+++ b/templates/white_label/client1/admin/candidatures.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Toutes les candidatures{% endblock %}
+{% block page_title %}Toutes les candidatures{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/creer_une_annonce.html.twig
+++ b/templates/white_label/client1/admin/creer_une_annonce.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Créer une annonce{% endblock %}
+{% block page_title %}Créer une annonce{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/csv_upload.html.twig
+++ b/templates/white_label/client1/admin/csv_upload.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}CSV Upload{% endblock %}
+{% block page_title %}CSV Upload{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/admin/cvtheque.html.twig
+++ b/templates/white_label/client1/admin/cvtheque.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}CVthèque{% endblock %}
+{% block page_title %}CVthèque{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/employe/edit.html.twig
+++ b/templates/white_label/client1/admin/employe/edit.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modifier employé{% endblock %}
+{% block page_title %}Modifier employé{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/employe/index.html.twig
+++ b/templates/white_label/client1/admin/employe/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tous les recruteurs{% endblock %}
+{% block page_title %}Tous les recruteurs{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/employe/new.html.twig
+++ b/templates/white_label/client1/admin/employe/new.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Nouvel employé{% endblock %}
+{% block page_title %}Nouvel employé{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/employe/show.html.twig
+++ b/templates/white_label/client1/admin/employe/show.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Employé #{{ employe.id }}{% endblock %}
+{% block page_title %}Employé #{{ employe.id }}{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/index.html.twig
+++ b/templates/white_label/client1/admin/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Administration{% endblock %}
+{% block page_title %}Administration{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/job_listing/edit.html.twig
+++ b/templates/white_label/client1/admin/job_listing/edit.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modification annonce{% endblock %}
+{% block page_title %}Modification annonce{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/job_listing/index.html.twig
+++ b/templates/white_label/client1/admin/job_listing/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Gestion des annonces{% endblock %}
+{% block page_title %}Gestion des annonces{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/admin/job_listing/new.html.twig
+++ b/templates/white_label/client1/admin/job_listing/new.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Créer une annonce{% endblock %}
+{% block page_title %}Créer une annonce{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/job_listing/show.html.twig
+++ b/templates/white_label/client1/admin/job_listing/show.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Annonce {{ job_listing.id }}{% endblock %}
+{% block page_title %}Annonce {{ job_listing.id }}{% endblock %}
+
 
 {% block body %}
     <h1>Annonce {{ job_listing.id }}</h1>

--- a/templates/white_label/client1/admin/recruiter/edit.html.twig
+++ b/templates/white_label/client1/admin/recruiter/edit.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modifier recruteur{% endblock %}
+{% block page_title %}Modifier recruteur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/recruiter/index.html.twig
+++ b/templates/white_label/client1/admin/recruiter/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tous les recruteurs{% endblock %}
+{% block page_title %}Tous les recruteurs{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/recruiter/new.html.twig
+++ b/templates/white_label/client1/admin/recruiter/new.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Nouveau recruteur{% endblock %}
+{% block page_title %}Nouveau recruteur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/recruiter/show.html.twig
+++ b/templates/white_label/client1/admin/recruiter/show.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Recruteur #{{ entreprise_profile.id }}{% endblock %}
+{% block page_title %}Recruteur #{{ entreprise_profile.id }}{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/user/edit.html.twig
+++ b/templates/white_label/client1/admin/user/edit.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modifier utilisateur{% endblock %}
+{% block page_title %}Modifier utilisateur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/user/index.html.twig
+++ b/templates/white_label/client1/admin/user/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tous les utilisateurs{% endblock %}
+{% block page_title %}Tous les utilisateurs{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/admin/user/new.html.twig
+++ b/templates/white_label/client1/admin/user/new.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Nouvel utilisateur{% endblock %}
+{% block page_title %}Nouvel utilisateur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/admin/user/show.html.twig
+++ b/templates/white_label/client1/admin/user/show.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Utilisateur{% endblock %}
+{% block page_title %}Utilisateur{% endblock %}
+
 
 {% block body %}
 <section class="p-0 m-0">

--- a/templates/white_label/client1/base.html.twig
+++ b/templates/white_label/client1/base.html.twig
@@ -69,10 +69,24 @@
 					<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 				</div>
 			{% endfor %}
-			{% block body %}{% endblock %}
-			{% block preview %}
-        	<a href="javascript:history.back()" class="d-none d-sm-block d-md-none btn btn-info fw-semibold text-uppercase px-4 my-5 me-3"><i class="mx-2 bi bi-arrow-left"></i>Retour</a>
-			{% endblock %}
+                        <div class="loader-container" id="loader-container" style="display:none;">
+                            <span class="loader"></span>
+                        </div>
+
+                        <section class="">
+                            <div class="breadcrumb-card mb-25 d-md-flex align-items-center justify-content-between">
+                                <div class="d-flex align-items-center">
+                                    <a href="javascript:history.back()" class="d-block btn btn-info fw-semibold text-uppercase me-3 btn_retour">
+                                        <i class="mx-2 bi bi-arrow-left"></i>Retour</a>
+                                    <h5 class="mb-0"> {% block page_title %}{% endblock %} </h5>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="recruteur-container">
+                            <div class="recruteur-block d-block p-5 mb-4">
+                        {% block body %}{% endblock %}
+                            </div>
+                        </section>
 		</div>
 		<script>
 

--- a/templates/white_label/client1/employe/index.html.twig
+++ b/templates/white_label/client1/employe/index.html.twig
@@ -1,21 +1,9 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Espace employé{% endblock %}
+{% block page_title %}Espace employé{% endblock %}
 
 {% block body %}
-    <section class="">
-        <div class="breadcrumb-card mb-25 d-md-flex align-items-center justify-content-between">
-            <h5 class="mb-0">Espace employé</h5>
-            <ol class="breadcrumb list-unstyled mt-0 mb-0 pl-0">
-                <li class="breadcrumb-item position-relative">
-                    <a href="{{ path('app_white_label_client1_employe') }}" class="d-inline-block position-relative">
-                        <i class="ri-home-8-line"></i> Tableau de bord
-                    </a>
-                </li>
-                <li class="breadcrumb-item position-relative">Espace employé</li>
-            </ol>
-        </div>
-    </section>
 
     <section class="top-dashboard">
         <div class="inner-block-dashboard d-md-flex justify-content-between align-items-center">

--- a/templates/white_label/client1/employe/profile.html.twig
+++ b/templates/white_label/client1/employe/profile.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes infos{% endblock %}
+{% block page_title %}Mes infos{% endblock %}
+
 
 {% block body %}
 <div class="example-wrapper">

--- a/templates/white_label/client1/home/annonce_view.html.twig
+++ b/templates/white_label/client1/home/annonce_view.html.twig
@@ -1,5 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
+{% block title %}Annonce{% endblock %}
+{% block page_title %}{{ annonce.titre }}{% endblock %}
+
 {% block body %}
     <div class="container">
         <div class="annonce-list p-2">

--- a/templates/white_label/client1/home/annonces.html.twig
+++ b/templates/white_label/client1/home/annonces.html.twig
@@ -1,5 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
+{% block title %}Annonces{% endblock %}
+{% block page_title %}Annonces{% endblock %}
+
 {% block body %}
     <div class="container">
         <div class="row">

--- a/templates/white_label/client1/home/index.html.twig
+++ b/templates/white_label/client1/home/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tableau de bord{% endblock %}
+{% block page_title %}Tableau de bord{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/recruiter/annonces.html.twig
+++ b/templates/white_label/client1/recruiter/annonces.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Toutes les annonces{% endblock %}
+{% block page_title %}Toutes les annonces{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/recruiter/candidatures.html.twig
+++ b/templates/white_label/client1/recruiter/candidatures.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Toutes les candidatures{% endblock %}
+{% block page_title %}Toutes les candidatures{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
+++ b/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
@@ -1,23 +1,9 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Créer une annonce{% endblock %}
+{% block page_title %}Publier une annonce{% endblock %}
 
 {% block body %}
-<div class="loader-container" id="loader-container" style="display:none;">
-    <span class="loader"></span>
-</div>
-
-<section class="">
-    <div class="breadcrumb-card mb-25 d-md-flex align-items-center justify-content-between">
-        <div class="d-flex align-items-center">
-            <a href="javascript:history.back()" class="d-block btn btn-info fw-semibold text-uppercase me-3 btn_retour">
-                <i class="mx-2 bi bi-arrow-left"></i>Retour</a>
-            <h5 class="mb-0"> Publier une annonce </h5>
-        </div>
-    </div>
-</section>
-<section class="recruteur-container">
-    <div class="recruteur-block d-block p-5 mb-4">
         <div class="offre-emploi-item">
             <div>
                 <h1>Publiez votre offre et recrutez les meilleurs talents</h1>
@@ -69,7 +55,4 @@
                 </div>
             </div>
             {{ form_end(form) }}
-        </div>
-    </div>
-</section>
 {% endblock %}

--- a/templates/white_label/client1/recruiter/csv_upload.html.twig
+++ b/templates/white_label/client1/recruiter/csv_upload.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}CSV Upload{% endblock %}
+{% block page_title %}CSV Upload{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/recruiter/cvtheque.html.twig
+++ b/templates/white_label/client1/recruiter/cvtheque.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}CVthèque{% endblock %}
+{% block page_title %}CVthèque{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/recruiter/index.html.twig
+++ b/templates/white_label/client1/recruiter/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Administration{% endblock %}
+{% block page_title %}Administration{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/referrer/become.html.twig
+++ b/templates/white_label/client1/referrer/become.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes infos Coopteur{% endblock %}
+{% block page_title %}Mes infos Coopteur{% endblock %}
+
 
 {% block body %}
 <div class="container">

--- a/templates/white_label/client1/referrer/cooptation/index.html.twig
+++ b/templates/white_label/client1/referrer/cooptation/index.html.twig
@@ -1,6 +1,7 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Cooptations{% endblock %}
+{% block page_title %}Recommander un ami{% endblock %}
 
 {% block body %}
     <div class="container mt-4">
@@ -12,8 +13,4 @@
             {{ form_end(form) }}
         </div>
     </div>
-<script src="{{ asset('assets/ckeditor5/ckeditor.js')}}"></script>
-<script>
-    ClassicEditor.create( document.querySelector( '#referral_description' ) )
-</script>
 {% endblock %}

--- a/templates/white_label/client1/referrer/cooptation/references.html.twig
+++ b/templates/white_label/client1/referrer/cooptation/references.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes références{% endblock %}
+{% block page_title %}Mes références{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/referrer/index.html.twig
+++ b/templates/white_label/client1/referrer/index.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Tableau de bord{% endblock %}
+{% block page_title %}Tableau de bord{% endblock %}
+
 
 {% block body %}
 

--- a/templates/white_label/client1/referrer/info.html.twig
+++ b/templates/white_label/client1/referrer/info.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes infos coopteur{% endblock %}
+{% block page_title %}Mes infos coopteur{% endblock %}
+
 
 {% block body %}
 <div class="container">

--- a/templates/white_label/client1/referrer/references.html.twig
+++ b/templates/white_label/client1/referrer/references.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes références{% endblock %}
+{% block page_title %}Mes références{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/referrer/rewards.html.twig
+++ b/templates/white_label/client1/referrer/rewards.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes récompences{% endblock %}
+{% block page_title %}Mes récompences{% endblock %}
+
 
 {% block body %}
 <div class="container">

--- a/templates/white_label/client1/referrer/stats.html.twig
+++ b/templates/white_label/client1/referrer/stats.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes statistiques{% endblock %}
+{% block page_title %}Mes statistiques{% endblock %}
+
 
 {% block body %}
 <div class="container">

--- a/templates/white_label/client1/user/annonce.html.twig
+++ b/templates/white_label/client1/user/annonce.html.twig
@@ -3,6 +3,8 @@
 {% block title %}
 	Annonce | Olona Talents
 {% endblock %}
+{% block page_title %}Annonce | Olona Talents{% endblock %}
+
 
 {% block stylesheets %}
 	{{ parent() }}

--- a/templates/white_label/client1/user/assistance.html.twig
+++ b/templates/white_label/client1/user/assistance.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Assistance{% endblock %}
+{% block page_title %}Assistance{% endblock %}
+
 
 {% block body %}
 <div class="biographie-profil mb-4 p-4 besoin_assitacne">

--- a/templates/white_label/client1/user/candidatures.html.twig
+++ b/templates/white_label/client1/user/candidatures.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes candidatures{% endblock %}
+{% block page_title %}Mes candidatures{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/user/index.html.twig
+++ b/templates/white_label/client1/user/index.html.twig
@@ -1,21 +1,9 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mon compte{% endblock %}
+{% block page_title %}Mon compte{% endblock %}
 
 {% block body %}
-    <section class="">
-        <div class="breadcrumb-card mb-25 d-md-flex align-items-center justify-content-between">
-            <h5 class="mb-0">Mon compte</h5>
-            <ol class="breadcrumb list-unstyled mt-0 mb-0 pl-0">
-                <li class="breadcrumb-item position-relative">
-                    <a href="{{ path('app_white_label_client1_user') }}" class="d-inline-block position-relative">
-                        <i class="ri-home-8-line"></i> Tableau de bord
-                    </a>
-                </li>
-                <li class="breadcrumb-item position-relative">Mon compte</li>
-            </ol>
-        </div>
-    </section>
 
     <section class="top-dashboard">
         <div class="inner-block-dashboard d-md-flex justify-content-between align-items-center">

--- a/templates/white_label/client1/user/missions.html.twig
+++ b/templates/white_label/client1/user/missions.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Trouver une mission{% endblock %}
+{% block page_title %}Trouver une mission{% endblock %}
+
 
 {% block body %}
 <style>

--- a/templates/white_label/client1/user/password.html.twig
+++ b/templates/white_label/client1/user/password.html.twig
@@ -1,6 +1,8 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Modifier mon mot de passe{% endblock %}
+{% block page_title %}Modifier mon mot de passe{% endblock %}
+
 
 {% block body %}
 <div class="biographie-profil mb-4 p-4 mjr_mdp">

--- a/templates/white_label/client1/user/profile.html.twig
+++ b/templates/white_label/client1/user/profile.html.twig
@@ -1,23 +1,9 @@
 {% extends 'white_label/client1/base.html.twig' %}
 
 {% block title %}Mes infos{% endblock %}
+{% block page_title %}Mon profil{% endblock %}
 
 {% block body %}
-<div class="loader-container" id="loader-container" style="display:none;">
-    <span class="loader"></span>
-</div>
-
-<section class="">
-    <div class="breadcrumb-card mb-25 d-md-flex align-items-center justify-content-between">
-        <div class="d-flex align-items-center">
-            <a href="javascript:history.back()" class="d-block btn btn-info fw-semibold text-uppercase me-3 btn_retour">
-                <i class="mx-2 bi bi-arrow-left"></i>Retour</a>
-            <h5 class="mb-0"> Mon profil </h5>
-        </div>
-    </div>
-</section>
-<section class="recruteur-container">
-    <div class="recruteur-block d-block p-5 mb-4">
         {% if form is defined %}
             {{ form_start(form, {'attr': {'data-turbo': 'false'}}) }}
             {{ form_widget(form) }}
@@ -33,6 +19,4 @@
             <button class="btn btn-primary mt-3">Sauvegarder</button>
             {{ form_end(employeForm) }}
         {% endif %}
-    </div>
-</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add loader and breadcrumb section in white label base layout
- introduce `page_title` block and use it in all white-label templates
- remove duplicate breadcrumb markup in individual pages
- drop inline scripts from referrer cooptation page

## Testing
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dad2b17c8330ad565e48b27c7120