### PR TITLE
Implement recruiter job offers list and unify padding

### DIFF
--- a/templates/white_label/client1/admin/cvtheque.html.twig
+++ b/templates/white_label/client1/admin/cvtheque.html.twig
@@ -12,7 +12,7 @@
     {% set filter_experience_years = app.request.query.get('filter-experience-years', '') %}
     {% set isPrem = '' %}
     <section class="recruteur-container">
-        <div class="recruteur-block d-block p-5 mb-4">
+        <div class="recruteur-block d-block p-4 mb-4">
             <div class="recruteur-top-item recruteur-filter">
                 <h1>CVthéque</h1>
                 <form id="filter-form" action="{{ path('app_white_label_client1_recruiter_cvtheque')}}" class="form-search filter-listing-form-wrapper" method="GET">
@@ -76,7 +76,7 @@
                 </form>
             </div>
         </div>
-        <div class="recruteur-block list-profil d-block p-5 mb-4">
+        <div class="recruteur-block list-profil d-block p-4 mb-4">
             <div class="layout-profil-container">
                 <div class="d-flex ordering-wrapper mb-4 justify-content-between">
                     <div class="results-count">Affichage de 1 - {{ searchResults|length }} sur {{ totalResults }} résultats</div>								

--- a/templates/white_label/client1/base.html.twig
+++ b/templates/white_label/client1/base.html.twig
@@ -83,7 +83,7 @@
                             </div>
                         </section>
                         <section class="recruteur-container">
-                            <div class="recruteur-block d-block p-5 mb-4">
+                            <div class="recruteur-block d-block p-4 mb-4">
                         {% block body %}{% endblock %}
                             </div>
                         </section>

--- a/templates/white_label/client1/home/annonce_view.html.twig
+++ b/templates/white_label/client1/home/annonce_view.html.twig
@@ -6,7 +6,7 @@
 {% block body %}
     <div class="container">
         <div class="annonce-list p-2">
-            <div class="annonce-item shadow p-5 m-4">
+            <div class="annonce-item shadow p-4 m-4">
                 <h1 class="card-title h2">{{ annonce.titre }}</h1>
                 <p class="text-muted small">
                     <i class="bi bi-circle-fill small mx-2 text-danger"></i> {{ getStatuses(annonce.status) }} 

--- a/templates/white_label/client1/recruiter/annonces.html.twig
+++ b/templates/white_label/client1/recruiter/annonces.html.twig
@@ -3,7 +3,71 @@
 {% block title %}Toutes les annonces{% endblock %}
 {% block page_title %}Toutes les annonces{% endblock %}
 
-
 {% block body %}
+    <section class="recruteur-container">
+        <div class="recruteur-block d-block p-4 mb-4">
+            <div class="offre-emploi-item">
+                <h1>Liste des offres d'emploi ({{ entreprise.joblistings|length }} offre{{ entreprise.joblistings|length > 1 ? 's' : '' }})</h1>
+                <div class="d-flex align-items-center justify-content-between">
+                    <div>
+                        <p>Vous avez {{ offres|length }} offre{{ offres|length > 1 ? 's' : '' }} d'emploi {{ labels[selectedStatus]|raw }}</p>
+                    </div>
+                    <div class="row w-50">
+                        <div class="col">
+                            <form action="{{ path('app_white_label_client1_recruiter_toutes_les_annonces') }}" method="get">
+                                <select class="form-select" name="status" onchange="this.form.submit()" aria-label="Default select example">
+                                    {% for label, status in statuses %}
+                                        <option value="{{ status }}" {% if selectedStatus == status %}selected{% endif %}>{{ label }}</option>
+                                    {% endfor %}
+                                </select>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <a href="{{ path('app_white_label_client1_recruiter_creer_une_annonce') }}" class="btn btn-primary mb-3">Créer une annonce</a>
+            {% if offres|length > 0 %}
+                {% for item in offres %}
+                    {% set offre = item[0] %}
+                    <article class="article-item_">
+                        <div class="offre-emploi-list">
+                            <div class="row">
+                                <div class="col-xl-8">
+                                    <div class="detail_annonce_">
+                                        <h2><a href="{{ path('app_white_label_annonce_view', {'jobId': offre.jobId })}}" class="btn-primary">{{ offre.titre }}</a></h2>
+                                        <h3><a href="#" class="btn-primary">{{ entreprise.nom }}</a></h3>
+                                        <div class="type_contact_">{{ offre.typeContrat }}</div>
+                                        <div class="description_courte_">
+                                            {{ offre.description|raw }}
+                                        </div>
+                                        <div class="info_publication_">
+                                            <span class="small fw-light">
+                                                <span class="badge rounded-pill px-2 text-bg-danger">{{ getStatuses(offre.status)}}</span>
+                                                <span class="small text-center mx-2">|</span>
+                                                <span class="">Publié {{ offre.dateCreation|time_ago }}</span>
+                                                <span class="small text-center mx-2">|</span>
+                                                <i class="bi bi-eye"></i> {{ offre.annonceVues|length }} vues
+                                                <span class="small text-center mx-2">|</span>
+                                                <i class="mx-2 bi bi-person-workspace"></i> DISTANCE
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-4 mt-4">
+                                    <p><a class="btn btn-light" href="#">{{ offre.applications|length }} candidat{{ offre.applications|length > 1 ? 's' : '' }} ont posté leur candidature</a></p>
+                                </div>
+                            </div>
+                        </div>
+                    </article>
+                {% endfor %}
+                {{ knp_pagination_render(offres) }}
 
+            {% else %}
+                <div class="text-center col-lg-6 col-sm-12 mx-auto">
+                    <img src="{{ asset('images/empty.png')}}" class="img-fluid">
+                    <p class="text-center">Vous n'avez pas encore d'annonce {{ labels[selectedStatus]|raw }}.</p>
+                </div>
+            {% endif %}
+        </div>
+    </section>
 {% endblock %}

--- a/templates/white_label/client1/recruiter/cvtheque.html.twig
+++ b/templates/white_label/client1/recruiter/cvtheque.html.twig
@@ -12,7 +12,7 @@
     {% set filter_experience_years = app.request.query.get('filter-experience-years', '') %}
     {% set isPrem = '' %}
     <section class="recruteur-container">
-        <div class="recruteur-block d-block p-5 mb-4">
+        <div class="recruteur-block d-block p-4 mb-4">
             <div class="recruteur-top-item recruteur-filter">
                 <h1>CVthéque</h1>
                 <form id="filter-form" action="{{ path('app_white_label_client1_recruiter_cvtheque')}}" class="form-search filter-listing-form-wrapper" method="GET">
@@ -76,7 +76,7 @@
                 </form>
             </div>
         </div>
-        <div class="recruteur-block list-profil d-block p-5 mb-4">
+        <div class="recruteur-block list-profil d-block p-4 mb-4">
             <div class="layout-profil-container">
                 <div class="d-flex ordering-wrapper mb-4 justify-content-between">
                     <div class="results-count">Affichage de 1 - {{ searchResults|length }} sur {{ totalResults }} résultats</div>								

--- a/templates/white_label/client1/referrer/cooptation/references.html.twig
+++ b/templates/white_label/client1/referrer/cooptation/references.html.twig
@@ -63,7 +63,7 @@
                 {{ knp_pagination_render(referrals, 'parts/_pagination.html.twig') }}
             </div>
             {% else %}
-            <div class="container p-5 m-5 text-center">
+            <div class="container p-4 m-5 text-center">
                 Vous n'avez effectuer aucune recommandation pour le moment <br>
                 <a href="{{path('app_dashboard_referrer_annonces')}}" class="btn btn-primary mx-5">Toutes les annonces</a>
             </div>

--- a/templates/white_label/client1/referrer/references.html.twig
+++ b/templates/white_label/client1/referrer/references.html.twig
@@ -52,7 +52,7 @@
         {{ knp_pagination_render(referrals, 'parts/_pagination.html.twig') }}
     </div>
     {% else %}
-    <div class="container p-5 mx-auto text-center">
+    <div class="container p-4 mx-auto text-center">
         Vous n'avez effectuer aucune recommandation pour le moment <br>
         <a href="{{path('app_white_label_client1_user_missions')}}" class="btn btn-primary px-5 rounded-pill my-4">Toutes les annonces</a>
     </div>

--- a/templates/white_label/client1/referrer/rewards.html.twig
+++ b/templates/white_label/client1/referrer/rewards.html.twig
@@ -76,7 +76,7 @@
                 {{ knp_pagination_render(referrals, 'parts/_pagination.html.twig') }}
             </div>
             {% else %}
-            <div class="container p-5 mx-auto text-center">
+            <div class="container p-4 mx-auto text-center">
                 Vous n'avez effectuer aucune recommandation pour le moment <br>
                 <a href="{{path('app_dashboard_referrer_annonces')}}" class="btn btn-primary px-5 rounded-pill my-4">Toutes les annonces</a>
             </div>


### PR DESCRIPTION
## Summary
- show recruiter job offers in brand white label
- standardize padding across white label pages

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ead10804833098c42fb5aff52f0a