### PR TITLE
Add apply button logic in white label view

### DIFF
--- a/src/WhiteLabel/Form/Client1/Candidat/ApplicationsType.php
+++ b/src/WhiteLabel/Form/Client1/Candidat/ApplicationsType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1\Candidat;
+
+use App\WhiteLabel\Entity\Client1\Candidate\Applications;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ApplicationsType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('lettreMotivation', TextareaType::class, [
+                'label' => false,
+                'required' => false,
+                'attr' => [
+                    'rows' => 6,
+                    'class' => 'ckeditor-textarea'
+                ]
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Applications::class,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Manager/Client1/ApplicationManager.php
+++ b/src/WhiteLabel/Manager/Client1/ApplicationManager.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\WhiteLabel\Manager\Client1;
+
+use App\WhiteLabel\Entity\Client1\Candidate\Applications;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Form\Form;
+
+class ApplicationManager
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private EntityManagerInterface $entityManager,
+    ){
+        $this->entityManager = $managerRegistry->getManager('client1');
+    }
+
+    public function init(): Applications
+    {
+        $application = new Applications();
+        $application->setDateCandidature(new \DateTime());
+        $application->setStatus(Applications::STATUS_PENDING);
+
+        return $application;
+    }
+
+    public function save(Applications $application): void
+    {
+        $this->entityManager->persist($application);
+        $this->entityManager->flush();
+    }
+
+    public function saveForm(Form $form): Applications
+    {
+        $application = $form->getData();
+        $this->save($application);
+
+        return $application;
+    }
+}

--- a/templates/white_label/client1/user/annonce.html.twig
+++ b/templates/white_label/client1/user/annonce.html.twig
@@ -65,15 +65,40 @@
                             <p>Aucune compétence spécifique requise.</p>
                         {% endif %}
                         <div class="btn-signUp">
-                            <a data-bs-toggle="modal" data-bs-target="#connectingModal" data-bs-href="{{ path('app_register', {'typology':'Candidat'}) }}" class="btn btn-primary">Postuler</a>
+                            {% if candidat is defined %}
+                                {% if candidat.status is same as(constant('App\\WhiteLabel\\Entity\\Client1\\CandidateProfile::STATUS_VALID')) or candidat.status is same as(constant('App\\WhiteLabel\\Entity\\Client1\\CandidateProfile::STATUS_FEATURED')) %}
+                                    {% if not applied %}
+                                    <div id="alert-application" class="my-4">
+                                        <button type="button" data-bs-toggle="modal" data-bs-target="#submitBtn" class="btn btn-primary">Postuler</button>
+                                    </div>
+                                    {% else %}
+                                    <div class="alert alert-light-primary d-flex align-items-center" role="alert">
+                                        <i class="bi bi-info-circle-fill me-1 me-sm-3"></i>
+                                        <div>
+                                            Vous avez déjà postulé à cette offre
+                                        </div>
+                                    </div>
+                                    {% endif %}
+                                {% else %}
+                                    <div class="alert alert-info d-flex align-items-center" role="alert">
+                                        <i class="bi bi-info-circle-fill me-1 me-sm-3"></i>
+                                        <div>
+                                            Votre profil doit être validé par un moderateur avant de pouvoir postuler à cette annonce.<br>
+                                            Veuillez vérifier régulièrement votre mail
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            {% else %}
+                                <a data-bs-toggle="modal" data-bs-target="#connectingModal" data-bs-href="{{ path('app_register', {'typology':'Candidat'}) }}" class="btn btn-primary">Postuler</a>
+                            {% endif %}
                             {% if app.user and app.user.referrerProfile is not null %}
                             <a href="{{ path('app_referrer_cooptation', {'jobId': jobOffer.jobId}) }}" class="btn btn-primary mx-3 px-3 px-sm-5">Recommander un ami</a>
                             {% endif %}
                         </div>
                     </div>
                 </div>
-			</div>
-			<div class="col-lg-4 col-md-12 rightSidebar">
+                        </div>
+                        <div class="col-lg-4 col-md-12 rightSidebar">
 				<div class="theiaStickySidebar">
 					<div class="side-bar">
 						<div class="sidebar-elements search-bx">
@@ -114,7 +139,34 @@
 					</div>
 				</div>
 			</div>
-		</div>
-	</div>
+        </div>
+        </div>
 </div>
+{% include "/tableau_de_bord/layout/_credit_modal_candidat.html.twig" %}
+{% if candidat is defined %}
+    <div class="modal fade" id="submitBtn" tabindex="-1" aria-labelledby="submitBtnLabel" >
+        <div class="modal-dialog  modal-dialog-centered modal-lg">
+            <div class="modal-content">
+            {{ form_start(form, {'attr': {'id':'applyJob', 'action': path('app_white_label_annonce_view',  {'jobId': jobOffer.jobId })}}) }}
+            <div class="modal-header">
+                <h1 class="modal-title fs-5 text-center fw-bold" id="submitBtnLabel">Rédigez votre lettre de motivation</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Prenez un moment pour nous parler de vous et de ce qui vous rend unique. Utilisez cet espace pour mettre en avant vos compétences, votre expérience et votre enthousiasme pour le poste auquel vous postulez.</p>
+                <div class="col-11 mx-auto">
+                    <div class="row">
+                    {{ form_widget(form)}}
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary fw-semibold text-uppercase" data-bs-dismiss="modal">Annuler</button>
+                <button type="submit" class="btn btn-primary fw-semibold text-uppercase">Envoyer</button>
+            </div>
+            {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add white label application manager
- include a simple application form for candidates
- save applications via manager in white label job view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68593071168883309e0de99a98216f9b