### PR TITLE
Add recruiter candidature detail page

### DIFF
--- a/src/WhiteLabel/Controller/Client1/RecruiterController.php
+++ b/src/WhiteLabel/Controller/Client1/RecruiterController.php
@@ -173,4 +173,26 @@ class RecruiterController extends AbstractController
             'langages' => $langages,
         ]);
     }
+
+    #[Route('/candidature/{id}', name: 'app_white_label_client1_recruiter_candidature_view')]
+    public function viewCandidature(int $id, ApplicationsRepository $applicationsRepository): Response
+    {
+        /** @var \App\WhiteLabel\Entity\Client1\User $user */
+        $user = $this->getUser();
+        $entreprise = $user?->getEntrepriseProfile();
+
+        if (!$entreprise) {
+            return $this->redirectToRoute('app_white_label_client1_user_profile');
+        }
+
+        $application = $applicationsRepository->find($id);
+
+        if (!$application || $application->getAnnonce()?->getEntreprise()?->getId() !== $entreprise->getId()) {
+            throw $this->createNotFoundException("Candidature introuvable.");
+        }
+
+        return $this->render('white_label/client1/recruiter/candidature_view.html.twig', [
+            'application' => $application,
+        ]);
+    }
 }

--- a/templates/white_label/client1/recruiter/candidature_view.html.twig
+++ b/templates/white_label/client1/recruiter/candidature_view.html.twig
@@ -1,0 +1,60 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Candidature #{{ application.id }}{% endblock %}
+{% block page_title %}Détail candidature{% endblock %}
+
+{% block body %}
+<div class="container mt-2">
+    <div class="card my-4">
+        <div class="card-header pt-3 bg-warning">
+            <h3 class="h4">Détails de la Candidature</h3>
+        </div>
+        <div class="card-body">
+            <h5 class="card-title">Candidature pour le poste : {{ application.annonce.titre }}</h5>
+            <p>
+                Candidat :
+                <a href="{{ path('app_white_label_client1_recruiter_view_profile', {'id': application.candidat.id}) }}">
+                    {{ application.candidat.candidat.nom }} {{ application.candidat.candidat.prenom }}
+                </a>
+            </p>
+            <p><strong>Email:</strong> {{ application.candidat.candidat.email }}</p>
+            <p><strong>Biographie:</strong> {{ application.candidat.resume|raw }}</p>
+            <p><strong>Compétences:</strong>
+                {% for skill in application.candidat.competences %}
+                    <span class="badge bg-dark">{{ skill.nom }}</span>
+                {% endfor %}
+            </p>
+            <p><strong>Lettre de motivation :</strong></p>
+            <p>{{ application.lettreMotivation }}</p>
+            {% if application.candidat.cv %}
+                <p><strong>Lien vers le CV :</strong> <a href="{{ asset('uploads/cv/' ~ application.candidat.cv) }}" class="btn btn-outline-primary rounded-pill btn-sm" target="_blank">Voir le CV</a></p>
+            {% endif %}
+            <p><strong>Date de candidature :</strong> {{ application.dateCandidature|date('d/m/Y') }}</p>
+            <p><strong>Status :</strong> {{ application.status }}</p>
+            {% if application.pretentionSalariale %}
+                <p><strong>Prétention salariale :</strong> {{ application.pretentionSalariale }}</p>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if application.annonce %}
+        <div class="card my-4">
+            <div class="card-header pt-3 bg-warning">
+                <h3 class="h4"><i class="fas fa-info-circle"></i> Informations sur le poste</h3>
+            </div>
+            <div class="card-body">
+                <h4 class="card-title">Titre du poste : {{ application.annonce.titre }}</h4>
+                <h5>Description :</h5>
+                <p>{{ application.annonce.description|raw }}</p>
+                <p><strong>Date de création</strong> : {{ application.annonce.dateCreation|date('d/m/Y') }}</p>
+                <p><strong>Date d'expiration</strong> : {{ application.annonce.dateExpiration|date('d/m/Y') }}</p>
+                <p><strong>Status</strong> : {{ application.annonce.status }}</p>
+                <p><strong>Salaire</strong> : {{ application.annonce.salaire }}</p>
+                <p><strong>Lieu</strong> : {{ application.annonce.lieu }}</p>
+                <p><strong>Type de contrat</strong> : {{ application.annonce.typeContrat }}</p>
+                <p><strong>Nombre de postes</strong> : {{ application.annonce.nombrePoste }}</p>
+            </div>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/white_label/client1/recruiter/candidatures.html.twig
+++ b/templates/white_label/client1/recruiter/candidatures.html.twig
@@ -29,6 +29,7 @@
                     </td>
                     <td>
                         <a class="btn btn-outline-primary btn-sm" href="{{ path('app_white_label_client1_recruiter_view_profile', {'id': application.candidat.id}) }}">Voir le profil</a>
+                        <a class="btn btn-outline-secondary btn-sm" href="{{ path('app_white_label_client1_recruiter_candidature_view', {'id': application.id}) }}">Voir la candidature</a>
                     </td>
                 </tr>
             {% else %}


### PR DESCRIPTION
## Summary
- add route to view a candidature
- create candidature view template
- link to candidature details in the recruiter's list

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685956fdccc88330b1bf3358fc746cb2