### PR TITLE
Add nav tabs for white label candidatures

### DIFF
--- a/templates/white_label/client1/user/candidatures.html.twig
+++ b/templates/white_label/client1/user/candidatures.html.twig
@@ -5,12 +5,41 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
+<div class="">
+    <ul class="nav nav-tabs" id="applicationTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="pending-tab" data-bs-toggle="tab" data-bs-target="#pending" type="button" role="tab">En attente</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="rendezvous-tab" data-bs-toggle="tab" data-bs-target="#rendezvous" type="button" role="tab">Rendez-vous</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="accepted-tab" data-bs-toggle="tab" data-bs-target="#accepted" type="button" role="tab">Acceptées</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="refused-tab" data-bs-toggle="tab" data-bs-target="#refused" type="button" role="tab">Non retenues</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="archived-tab" data-bs-toggle="tab" data-bs-target="#archived" type="button" role="tab">Archivées</button>
+        </li>
+    </ul>
 
-<div class="example-wrapper">
-    <h1>Mes candidatures</h1>
+    <div class="tab-content mt-3" id="applicationTabsContent">
+        <div class="tab-pane fade show active" id="pending" role="tabpanel" aria-labelledby="pending-tab">
+            {% include 'white_label/client1/user/candidatures/_list.html.twig' with {applications: pendings} %}
+        </div>
+        <div class="tab-pane fade" id="rendezvous" role="tabpanel" aria-labelledby="rendezvous-tab">
+            {% include 'white_label/client1/user/candidatures/_list.html.twig' with {applications: rendezvous} %}
+        </div>
+        <div class="tab-pane fade" id="accepted" role="tabpanel" aria-labelledby="accepted-tab">
+            {% include 'white_label/client1/user/candidatures/_list.html.twig' with {applications: accepteds} %}
+        </div>
+        <div class="tab-pane fade" id="refused" role="tabpanel" aria-labelledby="refused-tab">
+            {% include 'white_label/client1/user/candidatures/_list.html.twig' with {applications: refuseds} %}
+        </div>
+        <div class="tab-pane fade" id="archived" role="tabpanel" aria-labelledby="archived-tab">
+            {% include 'white_label/client1/user/candidatures/_list.html.twig' with {applications: archiveds} %}
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/templates/white_label/client1/user/candidatures/_list.html.twig
+++ b/templates/white_label/client1/user/candidatures/_list.html.twig
@@ -1,0 +1,29 @@
+{% if applications|default([])|length > 0 %}
+    <div class="table-responsive">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Annonce</th>
+                    <th>Status</th>
+                    <th>Déposé le</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for app in applications %}
+                <tr>
+                    <td>{{ app.annonce.titre }}</td>
+                    <td>{{ app.status|candidature_status_Label }}</td>
+                    <td>{{ app.dateCandidature|date('d/m/Y') }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="navigation">
+        {{ knp_pagination_render(applications, 'parts/_pagination.html.twig') }}
+    </div>
+{% else %}
+    <div class="text-center py-4">
+        <p>Aucune candidature.</p>
+    </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- group user applications by status
- display applications using Bootstrap nav-tabs

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859625d600083309a606fa4173bc628