### PR TITLE
Enable CV upload for white label profile

### DIFF
--- a/src/WhiteLabel/Manager/Client1/ProfileManager.php
+++ b/src/WhiteLabel/Manager/Client1/ProfileManager.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\WhiteLabel\Manager\Client1;
+
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Uid\Uuid;
+use App\WhiteLabel\Entity\Client1\User;
+use App\WhiteLabel\Entity\Client1\CandidateProfile;
+use App\WhiteLabel\Entity\Client1\EntrepriseProfile;
+use App\WhiteLabel\Entity\Client1\Candidate\CV;
+
+class ProfileManager
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private EntityManagerInterface $entityManager,
+    ) {
+        $this->entityManager = $managerRegistry->getManager('client1');
+    }
+
+    public function createCandidat(User $user): CandidateProfile
+    {
+        $candidate = new CandidateProfile();
+        $candidate->setCandidat($user);
+        $candidate->setIsValid(false);
+        $candidate->setStatus(CandidateProfile::STATUS_PENDING);
+        $candidate->setUid(new Uuid(Uuid::v1()));
+
+        return $candidate;
+    }
+
+    public function createCompany(User $user): EntrepriseProfile
+    {
+        $company = new EntrepriseProfile();
+        $company->setEntreprise($user);
+        $company->setStatus(EntrepriseProfile::STATUS_PENDING);
+
+        return $company;
+    }
+
+    public function saveCandidate(CandidateProfile $candidate): void
+    {
+        $this->entityManager->persist($candidate);
+        $this->entityManager->flush();
+    }
+
+    public function saveCompany(EntrepriseProfile $company): void
+    {
+        $this->entityManager->persist($company);
+        $this->entityManager->flush();
+    }
+
+    public function saveForm(Form $form)
+    {
+        $profile = $form->getData();
+        if ($profile instanceof EntrepriseProfile) {
+            $this->saveCompany($profile);
+        }
+        if ($profile instanceof CandidateProfile) {
+            $this->saveCandidate($profile);
+        }
+
+        return $profile;
+    }
+
+    public function saveCV(array $fileName, CandidateProfile $candidate): void
+    {
+        $cv = new CV();
+        $cv
+            ->setCvLink($fileName[0])
+            ->setSafeFileName($fileName[1])
+            ->setUploadedAt(new DateTime())
+            ->setCandidat($candidate);
+
+        if (!$this->entityManager->contains($candidate)) {
+            $this->entityManager->persist($candidate);
+        }
+
+        $this->entityManager->persist($cv);
+        $this->entityManager->flush();
+    }
+}

--- a/templates/white_label/client1/user/profile.html.twig
+++ b/templates/white_label/client1/user/profile.html.twig
@@ -4,7 +4,117 @@
 {% block page_title %}Mon profil{% endblock %}
 
 {% block body %}
-        {% if form is defined %}
+        {% if form is defined and type is defined and type == 'candidat' %}
+            <div class="form_compte_">
+            {{ form_start(form, {'attr': {'data-turbo': 'false'}}) }}
+            <div class="biographie-profil mb-4 p-4 apparition_">
+                <span class="fs-5 mb-1 fw-bold lh-base st-title">Votre CV</span>
+                <hr/>
+                <div class="row">
+                    <div class="col-lg-6 col-sm-12">
+                        {{ form_row(form.cv) }}
+                    </div>
+                    <div class="col-lg-6 col-sm-12 d-flex justify-content-center align-items-center">
+                        <div class="cv-pdf text-center">
+                            {% if form.vars.data.cv is defined and form.vars.data.cv is not null %}
+                                <a href="{{ asset('uploads/cv/' ~ form.vars.data.cv) }}" title="Ouvrir" target="_blank">
+                                    <i class="bi bi-filetype-pdf" style="font-size: 2rem;"></i>
+                                    <span class="small fw-light">{{ form.vars.data.cv }}</span>
+                                </a>
+                            {% else %}
+                                <i class="bi bi-info-circle" style="font-size: 1.2rem; color: red;"></i>
+                                <span class="small fw-light">Vous n'avez pas encore envoyé de CV. <br>Veuillez télécharger votre CV pour améliorer vos chances de sélection.</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="biographie-profil mb-4 p-4 apparition_">
+                <span class="fs-5 mb-1 fw-bold lh-base st-title">Informations personnelles</span>
+                <hr/>
+                <div class="row align-items-center justify-content-center">
+                    <div class="col-lg-2 col-sm-12 text-center">
+                        <div class="rounded-circle profile-img bg-image-candidat-account" style="background-image: url('{{ form.vars.data.fileName ? asset('uploads/experts/' ~ form.vars.data.fileName) : asset('uploads/experts/avatar-default.jpg') }}');cursor:pointer;" alt="Avatar">
+                            <div class="overlay-text">Changer la photo</div>
+                        </div>
+                        {{ form_widget(form.file) }}
+                        {{ form_errors(form.file) }}
+                    </div>
+                    <div class="col-lg-10 col-sm-12">
+                        <div class="row">
+                            <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.candidat.nom) }}
+                            </div>
+                            <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.candidat.prenom) }}
+                            </div>
+                        </div>
+                        {{ form_row(form.birthday) }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-6 col-sm-12">
+                        {{ form_row(form.candidat.email) }}
+                    </div>
+                    <div class="col-lg-6 col-sm-12">
+                        {{ form_row(form.candidat.telephone) }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-6 col-sm-12">
+                        {{ form_row(form.candidat.adress) }}
+                    </div>
+                    <div class="col-lg-6 col-sm-12">
+                        {{ form_row(form.candidat.city) }}
+                    </div>
+                </div>
+            </div>
+
+            <div class="biographie-profil mb-4 p-4 apparition_">
+                <span class="fs-5 mb-1 fw-bold lh-base st-title">Informations professionnelles</span>
+                <hr/>
+                {{ form_row(form.titre) }}
+                {{ form_row(form.secteurs) }}
+                {{ form_row(form.resume) }}
+                <div class="row">
+                    <div class="col-sm-12 col-md-4">{{ form_row(form.tarifCandidat.montant) }}</div>
+                    <div class="col-sm-12 col-md-4">{{ form_row(form.tarifCandidat.typeTarif) }}</div>
+                    <div class="col-sm-12 col-md-4">{{ form_row(form.tarifCandidat.currency) }}</div>
+                </div>
+                {{ form_row(form.competences) }}
+                {{ form_row(form.experiences) }}
+                {{ form_row(form.langages) }}
+            </div>
+
+            <div class="biographie-profil mb-4 p-4 apparition_">
+                <span class="fs-5 mb-1 fw-bold lh-base st-title">Profil social</span>
+                <hr/>
+                {{ form_row(form.social) }}
+            </div>
+
+            <button type="submit" class="btn btn-primary px-5 rounded-pill btn-lg mb-5">Sauvegarder</button>
+            <div style="display:none;">
+                {{ form_widget(form) }}
+            </div>
+            {{ form_end(form) }}
+            </div>
+            <script>
+                document.querySelector('.profile-img').addEventListener('click', function() {
+                    document.getElementById('{{ form.file.vars.id }}').click();
+                });
+
+                document.getElementById('{{ form.file.vars.id }}').addEventListener('change', function(event) {
+                    if (event.target.files && event.target.files[0]) {
+                        var reader = new FileReader();
+                        reader.onload = function(e) {
+                            document.querySelector('.profile-img').style.backgroundImage = 'url(' + e.target.result + ')';
+                        };
+                        reader.readAsDataURL(event.target.files[0]);
+                    }
+                });
+            </script>
+        {% elseif form is defined %}
             {{ form_start(form, {'attr': {'data-turbo': 'false', 'class': 'white-label-form'}}) }}
             {{ form_widget(form) }}
             <button class="btn btn-primary mt-3">Sauvegarder</button>


### PR DESCRIPTION
## Summary
- allow CV upload via FileUploader service in white-label profile controller
- style candidate profile form like the dashboard account page to include avatar, CV upload, and social sections
- wrap form markup with same container as dashboard
- add white-label specific ProfileManager service

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685982c7e3cc83309cdd71a0d90f3f4a