### PR TITLE
Switch OpenAI controllers to client1 services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -51,6 +51,10 @@ services:
         arguments:
             $apiKey: '%env(OPENAI_API_KEY)%' # Assurez-vous que cette variable d'environnement est définie
 
+    App\WhiteLabel\Service\Client1\OpenAITranslator:
+        arguments:
+            $apiKey: '%env(OPENAI_API_KEY)%'
+
     App\Controller\YouTubeOAuthController:
         public: true
         arguments:

--- a/src/WhiteLabel/Controller/Client1/OpenAi/AnnonceController.php
+++ b/src/WhiteLabel/Controller/Client1/OpenAi/AnnonceController.php
@@ -2,12 +2,12 @@
 
 namespace App\WhiteLabel\Controller\Client1\OpenAi;
 
-use App\Manager\OpenaiManager;
+use App\WhiteLabel\Manager\Client1\OpenaiManager;
 use App\WhiteLabel\Entity\Client1\Entreprise\JobListing;
 use App\Entity\Prestation;
-use App\Manager\CandidatManager;
-use App\Service\OpenAITranslator;
-use App\Service\PdfProcessor;
+use App\WhiteLabel\Manager\Client1\CandidatManager;
+use App\WhiteLabel\Service\Client1\OpenAITranslator;
+use App\WhiteLabel\Service\Client1\PdfProcessor;
 use App\WhiteLabel\Service\Client1\UserService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;

--- a/src/WhiteLabel/Controller/Client1/OpenAi/CandidatController.php
+++ b/src/WhiteLabel/Controller/Client1/OpenAi/CandidatController.php
@@ -4,11 +4,11 @@ namespace App\WhiteLabel\Controller\Client1\OpenAi;
 
 use App\WhiteLabel\Entity\Client1\Candidate\Competences;
 use Exception;
-use App\Service\PdfProcessor;
-use App\Manager\OpenaiManager;
+use App\WhiteLabel\Service\Client1\PdfProcessor;
+use App\WhiteLabel\Manager\Client1\OpenaiManager;
 use App\WhiteLabel\Entity\Client1\CandidateProfile;
-use App\Manager\CandidatManager;
-use App\Service\OpenAITranslator;
+use App\WhiteLabel\Manager\Client1\CandidatManager;
+use App\WhiteLabel\Service\Client1\OpenAITranslator;
 use App\WhiteLabel\Service\Client1\UserService;
 use App\WhiteLabel\Entity\Client1\Candidate\Experiences;
 use App\WhiteLabel\Repository\Client1\Candidate\CompetencesRepository;

--- a/src/WhiteLabel/Manager/Client1/CandidatManager.php
+++ b/src/WhiteLabel/Manager/Client1/CandidatManager.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\WhiteLabel\Manager\Client1;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+
+class CandidatManager
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private EntityManagerInterface $entityManager,
+    ) {
+        $this->entityManager = $managerRegistry->getManager('client1');
+    }
+}

--- a/src/WhiteLabel/Manager/Client1/OpenaiManager.php
+++ b/src/WhiteLabel/Manager/Client1/OpenaiManager.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\WhiteLabel\Manager\Client1;
+
+class OpenaiManager
+{
+    public function extractProfessionalSummary(string $text): string
+    {
+        $pattern = '/(\*{2,3}\s*Résumé Professionnel\s*\*{2,3}|#{2,3}\s*Résumé Professionnel\s*#{2,3}|Résumé Professionnel):\s*(.*?)\s*(\*{2,3}\s*Expérience[s]? Professionnelle[s]?\s*\*{2,3}|#{2,3}\s*Expérience[s]? Professionnelle[s]?\s*#{2,3}|Expérience[s]? Professionnelle[s]?):/s';
+        preg_match($pattern, $text, $matches);
+
+        if (isset($matches[2])) {
+            $summary = trim($matches[2]);
+            if (isset($summary[0]) && $summary[0] === ':') {
+                $summary = substr($summary, 1);
+            }
+            $summary = str_replace('-', '', $summary);
+            return $summary;
+        }
+
+        return '';
+    }
+
+    public function extractResumeCandidate(string $text): string
+    {
+        $pattern = '/(\*{2,3}\s*Forces\s*et\s*Faiblesses\s*\*{2,3}|\*{2,3}\s*Forces\s*\*{2,3}|#{2,3}\s*Forces\s*et\s*Faiblesses\s*#{2,3}|#{2,3}\s*Forces\s*#{2,3}|Forces et Faiblesses|Forces):\s*(.*?)\s*(\*{2,3}\s*Faiblesses\s*\*{2,3}|#{2,3}\s*Faiblesses\s*#{2,3}|\*{2,3}\s*Autres Informations\s*\*{2,3}|#{2,3}\s*Autres Informations\s*#{2,3}|Faiblesses|Autres Informations)/s';
+        preg_match($pattern, $text, $matches);
+
+        if (isset($matches[2])) {
+            $summary = trim($matches[2]);
+            if (isset($summary[0]) && $summary[0] === ':') {
+                $summary = substr($summary, 1);
+            }
+            return $summary;
+        }
+
+        return '';
+    }
+
+    public function extractCandidateTools(string $text): string
+    {
+        $pattern = '/Outils\s*(.*?)\s*Langages/s';
+        preg_match($pattern, $text, $matches);
+
+        if (isset($matches[1])) {
+            $summary = trim($matches[1]);
+            if (isset($summary[0]) && $summary[0] === ':') {
+                $summary = substr($summary, 1);
+            }
+            return $summary;
+        }
+
+        return '';
+    }
+
+    public function extractJsonAndText(string $text): array
+    {
+        $delimiter = "```json";
+        $parts = explode($delimiter, $text);
+
+        $jsonString = trim($parts[1] ?? '', " \t\n\r\0\x0B`");
+        $jsonData = json_decode($jsonString, true);
+
+        return $jsonData ?? [];
+    }
+
+    public function extractCleanAndShortText(string $text): array
+    {
+        $delimiter = "####";
+        $parts = explode($delimiter, $text);
+
+        $cleanDescription = str_replace("cleanDescription", "", trim($parts[2] ?? ''));
+        $shortDescription = str_replace("shortDescription", "", trim($parts[1] ?? ''));
+
+        return [
+            $cleanDescription,
+            $shortDescription,
+        ];
+    }
+}

--- a/src/WhiteLabel/Service/Client1/OpenAITranslator.php
+++ b/src/WhiteLabel/Service/Client1/OpenAITranslator.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\WhiteLabel\Service\Client1;
+
+use App\Twig\AppExtension;
+use App\WhiteLabel\Service\Client1\PdfProcessor;
+use App\WhiteLabel\Entity\Client1\CandidateProfile;
+use App\WhiteLabel\Entity\Client1\Entreprise\JobListing;
+use App\WhiteLabel\Entity\Client1\Prestation;
+use App\WhiteLabel\Manager\Client1\CandidatManager;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class OpenAITranslator
+{
+    private string $projectDir;
+
+    public function __construct(
+        private HttpClientInterface $client,
+        private AppExtension $appExtension,
+        private CandidatManager $candidatManager,
+        private PdfProcessor $pdfProcessor,
+        private string $apiKey,
+        ParameterBagInterface $params
+    ) {
+        $this->projectDir = $params->get('kernel.project_dir');
+    }
+
+    public function translate(string $text, string $sourceLang, string $targetLang): string
+    {
+        $segments = $this->splitTextIntoSegments($text, 450);
+        $translatedText = '';
+
+        foreach ($segments as $segment) {
+            try {
+                $response = $this->client->request('POST', 'https://api.openai.com/v1/completions', [
+                    'headers' => [
+                        'Authorization' => 'Bearer ' . $this->apiKey,
+                    ],
+                    'json' => [
+                        'model' => 'text-davinci-003',
+                        'prompt' => "Please translate the following text from {$sourceLang} to {$targetLang}, but do not translate the HTML tags and their attributes: '{$segment}'",
+                        'max_tokens' => 1024,
+                    ],
+                    'timeout' => 60,
+                ]);
+
+                $content = $response->toArray();
+                $translatedSegment = $content['choices'][0]['text'] ?? '';
+                $translatedText .= $translatedSegment;
+            } catch (\Exception $e) {
+                return 'Error: ' . $e->getMessage();
+            }
+        }
+
+        return $translatedText;
+    }
+
+    public function translateCategory(string $text, string $sourceLang, string $targetLang): string
+    {
+        try {
+            $response = $this->client->request('POST', 'https://api.openai.com/v1/completions', [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->apiKey,
+                ],
+                'json' => [
+                    'model' => 'text-davinci-003',
+                    'prompt' => "Please translate the following text from {$sourceLang} to {$targetLang} : '{$text}'",
+                    'max_tokens' => 1024,
+                ],
+                'timeout' => 60,
+            ]);
+
+            $content = $response->toArray();
+            $translatedSegment = $content['choices'][0]['text'] ?? '';
+
+            return $translatedSegment;
+        } catch (\Exception $e) {
+            return 'Error: ' . $e->getMessage();
+        }
+    }
+
+    public function generateDescription(string $text)
+    {
+        try {
+            $response = $this->client->request('POST', 'https://api.openai.com/v1/completions', [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->apiKey,
+                ],
+                'json' => [
+                    'model' => 'text-davinci-003',
+                    'prompt' => "Write in french a creative and informative description for an AI tools category named '{$text}':",
+                    'max_tokens' => 1024,
+                ],
+                'timeout' => 60,
+            ]);
+
+            $content = $response->toArray();
+            $description = $content['choices'][0]['text'] ?? '';
+        } catch (\Exception $e) {
+            return 'Error: ' . $e->getMessage();
+        }
+
+        return $description;
+    }
+
+    private function splitTextIntoSegments($text, $maxTokens = 1024)
+    {
+        $segments = [];
+        $currentSegment = '';
+        $buffer = '';
+
+        foreach (explode(' ', $text) as $word) {
+            $buffer .= $word . ' ';
+            if (strpos($word, '.') !== false || strpos($word, '</p>') !== false) {
+                if ($this->appExtension->countTokens($currentSegment . $buffer) > $maxTokens) {
+                    $segments[] = trim($currentSegment);
+                    $currentSegment = $buffer;
+                    $buffer = '';
+                } else {
+                    $currentSegment .= $buffer;
+                    $buffer = '';
+                }
+            }
+        }
+
+        if (!empty(trim($currentSegment . $buffer))) {
+            $segments[] = trim($currentSegment . $buffer);
+        }
+
+        return $segments;
+    }
+
+    public function trans($text)
+    {
+        $scriptPath = $this->projectDir . '/assets/node_app/index.js';
+        $nodePath = '/root/.nvm/versions/node/v18.17.0/bin/node';
+        $command = sprintf('sudo %s %s %s %s 2>&1', escapeshellarg($nodePath), escapeshellarg($scriptPath), escapeshellarg($text), escapeshellarg($this->apiKey));
+
+        exec($command, $output, $return_var);
+
+        if ($return_var === 0) {
+            return implode("\n", $output);
+        }
+
+        return "Erreur lors de l'exécution du script index.js";
+    }
+
+    public function parse(CandidateProfile $candidateProfile)
+    {
+        $cv = $candidateProfile->getCv();
+        if ($cv === null) {
+            return 'CV manquant';
+        }
+        $scriptPath = $this->projectDir . '/assets/node_app/test1.js';
+        $nodePath = '/root/.nvm/versions/node/v18.17.0/bin/node';
+        $command = sprintf('sudo %s %s %s %s 2>&1', escapeshellarg($nodePath), escapeshellarg($scriptPath), escapeshellarg($candidateProfile->getCv()), escapeshellarg($this->apiKey));
+        exec($command, $output, $return_var);
+
+        if ($return_var === 0) {
+            return implode("\n", $output);
+        }
+
+        return "Erreur lors de l'exécution du script parse.js";
+    }
+
+    public function report(CandidateProfile $candidateProfile)
+    {
+        $scriptPath = $this->projectDir . '/assets/node_app/assistant.js';
+        $nodePath = '/root/.nvm/versions/node/v18.17.0/bin/node';
+        $command = sprintf('sudo %s %s %s %s %s 2>&1', escapeshellarg($nodePath), escapeshellarg($scriptPath), escapeshellarg($candidateProfile->getCv()), escapeshellarg($this->apiKey), escapeshellarg($candidateProfile->getId()));
+
+        exec($command, $output, $return_var);
+        if ($return_var === 0) {
+            return implode("\n", $output);
+        }
+
+        return "Erreur lors de l'exécution du script assistant.js";
+    }
+
+    public function metaDescription(JobListing $annonce)
+    {
+        $scriptPath = $this->projectDir . '/assets/node_app/shortdesc.js';
+        $nodePath = '/root/.nvm/versions/node/v18.17.0/bin/node';
+        $command = sprintf('sudo %s %s %s %s %s 2>&1', escapeshellarg($nodePath), escapeshellarg($scriptPath), escapeshellarg($annonce->getDescription()), escapeshellarg($this->apiKey), escapeshellarg($annonce->getId()));
+
+        exec($command, $output, $return_var);
+        if ($return_var === 0) {
+            return implode("\n", $output);
+        }
+
+        return "Erreur lors de l'exécution du script shortdesc.js";
+    }
+
+    public function resumePrestation(Prestation $prestation)
+    {
+        $scriptPath = $this->projectDir . '/assets/node_app/prestation.js';
+        $nodePath = '/root/.nvm/versions/node/v18.17.0/bin/node';
+        $command = sprintf('sudo %s %s %s %s %s 2>&1', escapeshellarg($nodePath), escapeshellarg($scriptPath), escapeshellarg($prestation->getDescription()), escapeshellarg($this->apiKey), escapeshellarg($prestation->getTitre()));
+
+        exec($command, $output, $return_var);
+        if ($return_var === 0) {
+            return implode("\n", $output);
+        }
+
+        return "Erreur lors de l'exécution du script prestation.js";
+    }
+}

--- a/src/WhiteLabel/Service/Client1/PdfProcessor.php
+++ b/src/WhiteLabel/Service/Client1/PdfProcessor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\WhiteLabel\Service\Client1;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use App\WhiteLabel\Entity\Client1\CandidateProfile;
+
+class PdfProcessor
+{
+    private HttpClientInterface $httpClient;
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(
+        HttpClientInterface $httpClient,
+        private FileUploader $fileUploader,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->httpClient = $httpClient;
+        $this->entityManager = $entityManager;
+    }
+
+    public function processPdf(int $candidatId)
+    {
+        $candidateProfile = $this->entityManager->getRepository(CandidateProfile::class)->find($candidatId);
+        $pdfPath = $this->fileUploader->getTargetDirectory() . '/' . $candidateProfile->getCv();
+
+        $boundary = '----WebKitFormBoundary' . md5(time());
+        $body = "--$boundary\r\n" .
+            "Content-Disposition: form-data; name=\"pdf\"; filename=\"" . basename($pdfPath) . "\"\r\n" .
+            "Content-Type: application/pdf\r\n\r\n" .
+            file_get_contents($pdfPath) . "\r\n" .
+            "--$boundary--\r\n";
+
+        $response = $this->httpClient->request('POST', 'https://technique.olona-talents.com/api/tesseract', [
+            'headers' => [
+                'Content-Type' => 'multipart/form-data; boundary=' . $boundary,
+            ],
+            'body' => $body,
+            'timeout' => 60,
+        ]);
+
+        return $response->getContent();
+    }
+}


### PR DESCRIPTION
## Summary
- add client1 OpenAI services and managers
- wire the new services in `services.yaml`
- update OpenAI controllers to use the white label classes

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2bffebc8330a648e4bec3a8a51c