### PR TITLE
Remove premium indexes from white label

### DIFF
--- a/src/WhiteLabel/Command/Client1/CreateElasticsearchIndexCommand.php
+++ b/src/WhiteLabel/Command/Client1/CreateElasticsearchIndexCommand.php
@@ -171,11 +171,14 @@ class CreateElasticsearchIndexCommand extends Command
         }
 
         try {
-            $this->elasticsearch->createIndex('candidate_premium_index', $settings, $mappingsCandidate);
-            $io->success('Index "candidate_premium_index" created successfully.');
+            $this->elasticsearch->createIndex('candidate_white_label_index', $settings, $mappingsCandidate);
+            $io->success('Index "candidate_white_label_index" created successfully.');
         } catch (\Exception $e) {
             $io->error('Error creating index: ' . $e->getMessage());
         }
+
+
+        // White label has no premium candidate index
 
         try {
             $this->elasticsearch->createIndex('joblisting_index', $settings, $mappingsJoblisting);
@@ -184,9 +187,10 @@ class CreateElasticsearchIndexCommand extends Command
             $io->error('Error creating index: ' . $e->getMessage());
         }
 
+        // White label specific job listing index
         try {
-            $this->elasticsearch->createIndex('joblisting_premium_index', $settings, $mappingsJoblisting);
-            $io->success('Index "joblisting_premium_index" created successfully.');
+            $this->elasticsearch->createIndex('joblisting_white_label_index', $settings, $mappingsJoblisting);
+            $io->success('Index "joblisting_white_label_index" created successfully.');
         } catch (\Exception $e) {
             $io->error('Error creating index: ' . $e->getMessage());
         }

--- a/src/WhiteLabel/Command/Client1/DeindexElasticSearchCommand.php
+++ b/src/WhiteLabel/Command/Client1/DeindexElasticSearchCommand.php
@@ -46,7 +46,7 @@ class DeindexElasticSearchCommand extends Command
         foreach ($validProfiles as $profile) {
             if ($profile->isGeneretated() != true) {
                 $params = [
-                    'index' => 'candidate_index',
+                    'index' => 'candidate_white_label_index',
                     'id'    => $profile->getId(),
                 ];
     
@@ -71,7 +71,7 @@ class DeindexElasticSearchCommand extends Command
         foreach ($validJobListings as $job) {
             if ($job->isGeneretated() != true) {
                 $params = [
-                    'index' => 'joblisting_index',
+                    'index' => 'joblisting_white_label_index',
                     'id'    => $job->getId(),
                 ];
     
@@ -96,7 +96,7 @@ class DeindexElasticSearchCommand extends Command
         foreach ($validPrestations as $prestation) {
             if ($prestation->isGeneretated() != true) {
                 $params = [
-                    'index' => 'joblisting_index',
+                    'index' => 'joblisting_white_label_index',
                     'id'    => $prestation->getId(),
                 ];
     

--- a/src/WhiteLabel/Command/Client1/IndexCandidateProfilesCommand.php
+++ b/src/WhiteLabel/Command/Client1/IndexCandidateProfilesCommand.php
@@ -106,6 +106,12 @@ class IndexCandidateProfilesCommand extends Command
                 'body'  => $body,
             ]);
 
+            $this->elasticsearch->index([
+                'index' => 'candidate_white_label_index',
+                'id'    => $profile->getId(),
+                'body'  => $body,
+            ]);
+
             $output->writeln('Indexed Candidate Profile ID: ' . $profile->getId());
         }
 
@@ -156,12 +162,12 @@ class IndexCandidateProfilesCommand extends Command
             }
 
             $this->elasticsearch->index([
-                'index' => 'candidate_premium_index',
+                'index' => 'candidate_white_label_index',
                 'id'    => $profile->getId(),
                 'body'  => $body,
             ]);
 
-            $output->writeln('Indexed Premium Candidate Profile ID: ' . $profile->getId());
+            $output->writeln('Indexed Candidate Profile ID: ' . $profile->getId());
         }
 
         return Command::SUCCESS;

--- a/src/WhiteLabel/Command/Client1/IndexJobListingsCommand.php
+++ b/src/WhiteLabel/Command/Client1/IndexJobListingsCommand.php
@@ -89,6 +89,12 @@ class IndexJobListingsCommand extends Command
                 'body'  => $body,
             ]);
 
+            $this->elasticsearch->index([
+                'index' => 'joblisting_white_label_index',
+                'id'    => $annonce->getId(),
+                'body'  => $body,
+            ]);
+
             $output->writeln('Indexed Joblisting ID: ' . $annonce->getId());
         }
 
@@ -136,12 +142,12 @@ class IndexJobListingsCommand extends Command
             }
 
             $this->elasticsearch->index([
-                'index' => 'joblisting_premium_index',
+                'index' => 'joblisting_white_label_index',
                 'id'    => $annonce->getId(),
                 'body'  => $body,
             ]);
 
-            $output->writeln('Indexed Premium Joblisting ID: ' . $annonce->getId());
+            $output->writeln('Indexed Joblisting ID: ' . $annonce->getId());
         }
 
         return Command::SUCCESS;

--- a/src/WhiteLabel/Manager/Client1/CVThequeManager.php
+++ b/src/WhiteLabel/Manager/Client1/CVThequeManager.php
@@ -150,7 +150,7 @@ class CVThequeManager
         }
 
         return [
-            'index' => 'candidate_profile_index',
+            'index' => 'candidate_white_label_index',
             'body'  => array_merge([
                 'from' => $from,
                 'size' => $size,
@@ -160,29 +160,14 @@ class CVThequeManager
     
     public function getParamsPremiumCandidates(int $from, int $size, ?string $query): array
     {
-        return [
-            'index' => 'candidate_premium_index',
-            'body'  => [
-                'from' => $from,
-                'size' => $size,
-                'query' => [
-                    'multi_match' => [
-                        'query'  => $query,
-                        'fields' => [
-                            'titre', 'resume', 'localisation', 'technologies', 'tools', 'badKeywords', 'resultFree', 'metaDescription', 'traductionEn', 
-                            'competences.nom', 'experiences.titre', 'experiences.description','secteurs.nom', 'langages.nom'
-                        ],
-                        'fuzziness' => 'AUTO',
-                    ],
-                ],
-            ],
-        ];
+        // White label uses the same index for boosted candidates
+        return $this->getParamsCandidates($from, $size, $query);
     }
 
     public function getParamsJoblisting(int $from, int $size, ?string $query): array
     {
         return [
-            'index' => 'joblisting_index',
+            'index' => 'joblisting_white_label_index',
             'body'  => [
                 'from' => $from,
                 'size' => $size,
@@ -226,22 +211,7 @@ class CVThequeManager
     
     public function getParamsPremiumJoblisting(int $from, int $size, ?string $query): array
     {
-        return [
-            'index' => 'joblisting_premium_index',
-            'body'  => [
-                'from' => $from,
-                'size' => $size,
-                'query' => [
-                    'multi_match' => [
-                        'query'  => $query,
-                        'fields' => [
-                            'titre', 'description', 'lieu', 'shortDescription', 'typeContrat', 'budgetAnnonce', 
-                            'competences.nom', 'secteur.nom', 'langues.nom'
-                        ],
-                        'fuzziness' => 'AUTO',
-                    ],
-                ],
-            ],
-        ];
+        // White label uses the same index for boosted job listings
+        return $this->getParamsJoblisting($from, $size, $query);
     }
 }


### PR DESCRIPTION
## Summary
- remove references to premium indexes in white label commands
- index white label data using `candidate_white_label_index` and `joblisting_white_label_index`
- adjust CV database manager to search and boost on white label indexes only
- de-index white label records from the correct indexes

## Testing
- `./bin/phpunit --version` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ca225988330bc88d0c4d4e4ac3e