### PR TITLE
Fix duplicate command names for white label

### DIFF
--- a/src/WhiteLabel/Command/Client1/CreateElasticsearchIndexCommand.php
+++ b/src/WhiteLabel/Command/Client1/CreateElasticsearchIndexCommand.php
@@ -10,10 +10,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'app:create-elasticsearch-index',
+    name: 'app:client1:create-elasticsearch-index',
     description: 'Create Elasticsearch indices',
     hidden: false,
-    aliases: ['app:create-elasticsearch-index']
+    aliases: ['app:client1:create-elasticsearch-index']
 )]
 class CreateElasticsearchIndexCommand extends Command
 {

--- a/src/WhiteLabel/Command/Client1/DeindexElasticSearchCommand.php
+++ b/src/WhiteLabel/Command/Client1/DeindexElasticSearchCommand.php
@@ -13,10 +13,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'app:deindex-elastic-search',
+    name: 'app:client1:deindex-elastic-search',
     description: 'De-index from Elasticsearch',
     hidden: false,
-    aliases: ['app:deindex-elastic-search']
+    aliases: ['app:client1:deindex-elastic-search']
 )]
 class DeindexElasticSearchCommand extends Command
 {

--- a/src/WhiteLabel/Command/Client1/DeleteElasticsearchIndexCommand.php
+++ b/src/WhiteLabel/Command/Client1/DeleteElasticsearchIndexCommand.php
@@ -12,10 +12,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'app:delete-elasticsearch-index',
+    name: 'app:client1:delete-elasticsearch-index',
     description: 'Delete an Elasticsearch index',
     hidden: false,
-    aliases: ['app:delete-elasticsearch-index']
+    aliases: ['app:client1:delete-elasticsearch-index']
 )]
 class DeleteElasticsearchIndexCommand extends Command
 {

--- a/src/WhiteLabel/Command/Client1/IndexCandidateProfilesCommand.php
+++ b/src/WhiteLabel/Command/Client1/IndexCandidateProfilesCommand.php
@@ -12,10 +12,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'app:index-candidate-profiles',
+    name: 'app:client1:index-candidate-profiles',
     description: 'Index all candidate profiles to Elasticsearch',
     hidden: false,
-    aliases: ['app:index-candidate-profiles']
+    aliases: ['app:client1:index-candidate-profiles']
 )]
 class IndexCandidateProfilesCommand extends Command
 {

--- a/src/WhiteLabel/Command/Client1/IndexJobListingsCommand.php
+++ b/src/WhiteLabel/Command/Client1/IndexJobListingsCommand.php
@@ -12,10 +12,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
-    name: 'app:index-joblistings',
+    name: 'app:client1:index-joblistings',
     description: 'Index all joblistings to Elasticsearch',
     hidden: false,
-    aliases: ['app:index-joblistings']
+    aliases: ['app:client1:index-joblistings']
 )]
 class IndexJobListingsCommand extends Command
 {

--- a/src/WhiteLabel/Command/Client1/ReportProfileCommand.php
+++ b/src/WhiteLabel/Command/Client1/ReportProfileCommand.php
@@ -17,10 +17,10 @@ use App\Service\ErrorLogger;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[AsCommand(
-    name: 'app:generate-report',
+    name: 'app:client1:generate-report',
     description: 'Generate openai report.',
     hidden: false,
-    aliases: ['app:generate-report']
+    aliases: ['app:client1:generate-report']
 )]
 class ReportProfileCommand extends Command
 {
@@ -127,7 +127,7 @@ class ReportProfileCommand extends Command
         $cronLog = new CronLog();
         $cronLog->setStartTime($startTime)
             ->setEndTime($endTime)
-            ->setCommandName('app:generate-report')
+            ->setCommandName('app:client1:generate-report')
             ->setEmailsSent($emailsSent);
 
         $this->em->persist($cronLog);


### PR DESCRIPTION
## Summary
- rename white label console commands to avoid name conflicts

## Testing
- `composer test` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdf8c448c8330a26aa0dd1bfa4739