### PR TITLE
Add Employe management CRUD

### DIFF
--- a/src/WhiteLabel/Controller/Client1/Crud/EmployeController.php
+++ b/src/WhiteLabel/Controller/Client1/Crud/EmployeController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\WhiteLabel\Controller\Client1\Crud;
+
+use App\WhiteLabel\Entity\Client1\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Knp\Component\Pager\PaginatorInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use App\WhiteLabel\Entity\Client1\Finance\Employe;
+use App\WhiteLabel\Form\Client1\Finance\EmployeType;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+#[IsGranted('ROLE_ADMIN')]
+#[Route('/wl-admin/employe')]
+class EmployeController extends AbstractController
+{
+    public function __construct(
+        private ManagerRegistry $managerRegistry,
+        private EntityManagerInterface $entityManager,
+        private PaginatorInterface $paginatorInterface
+    ){
+        $this->entityManager = $managerRegistry->getManager('client1');
+    }
+    
+    #[Route('/', name: 'app_white_label_employe_index', methods: ['GET'])]
+    public function index(
+        Request $request,
+        Security $security
+    ): Response
+    {
+        $page = $request->query->getInt('page', 1);
+        /** @var User $user */
+        $user = $security->getUser();
+        $userId = $user->getId();
+        $canListAll = true;
+        $employes = $this->entityManager->getRepository(Employe::class)->paginateRecipes($page, $this->paginatorInterface, $canListAll ? null : $userId);
+
+        return $this->render('white_label/client1/admin/finance_employe/index.html.twig', [
+            'employes' => $employes,
+        ]);
+    }
+
+    #[Route('/new', name: 'app_white_label_employe_new', methods: ['GET', 'POST'])]
+    public function new(
+        Request $request,
+    ): Response
+    {
+        $employe = new Employe();
+        $form = $this->createForm(EmployeType::class, $employe);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->entityManager->persist($employe);
+            $this->entityManager->flush();
+
+            return $this->redirectToRoute('app_white_label_employe_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('white_label/client1/admin/finance_employe/new.html.twig', [
+            'employe' => $employe,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_white_label_employe_show', methods: ['GET'])]
+    public function show(Employe $employe): Response
+    {
+        return $this->render('white_label/client1/admin/finance_employe/show.html.twig', [
+            'employe' => $employe,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'app_white_label_employe_edit', methods: ['GET', 'POST'])]
+    public function edit(
+        Request $request,
+        Employe $employe,
+    ): Response
+    {
+        $form = $this->createForm(EmployeType::class, $employe);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->entityManager->flush();
+
+            return $this->redirectToRoute('app_white_label_employe_show', ['id' => $employe->getId()], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('white_label/client1/admin/finance_employe/edit.html.twig', [
+            'employe' => $employe,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_white_label_employe_delete', methods: ['POST'])]
+    public function delete(Request $request, Employe $employe, EntityManagerInterface $entityManager): Response
+    {
+        if ($this->isCsrfTokenValid('delete'.$employe->getId(), $request->request->get('_token'))) {
+            $entityManager->remove($employe);
+            $entityManager->flush();
+        }
+
+        return $this->redirectToRoute('app_white_label_employe_index', [], Response::HTTP_SEE_OTHER);
+    }
+}

--- a/src/WhiteLabel/Controller/Client1/Crud/ReferreProfileController.php
+++ b/src/WhiteLabel/Controller/Client1/Crud/ReferreProfileController.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 #[IsGranted('ROLE_ADMIN')]
-#[Route('/wl-admin/employe')]
+#[Route('/wl-admin/coopteur')]
 class ReferreProfileController extends AbstractController
 {
     public function __construct(

--- a/src/WhiteLabel/Repository/Client1/Finance/EmployeRepository.php
+++ b/src/WhiteLabel/Repository/Client1/Finance/EmployeRepository.php
@@ -112,6 +112,30 @@ class EmployeRepository extends ServiceEntityRepository
         );
     }
 
+    public function paginateRecipes(int $page, PaginatorInterface $paginator, ?int $userId): PaginationInterface
+    {
+        $queryBuilder = $this
+            ->createQueryBuilder('e')
+            ->select('e, u.nom AS nom, COUNT(s.id) AS simCount')
+            ->leftJoin('e.user', 'u')
+            ->leftJoin('e.simulateurs', 's')
+            ->groupBy('e.id')
+            ->addOrderBy('e.id', 'DESC');
+
+        if ($userId) {
+            $queryBuilder
+                ->andWhere('u.id = :uid')
+                ->setParameter('uid', $userId);
+        }
+
+        return $paginator->paginate(
+            $queryBuilder,
+            $page,
+            20,
+            []
+        );
+    }
+
 //    /**
 //     * @return Employe[] Returns an array of Employe objects
 //     */

--- a/templates/white_label/client1/admin/finance_employe/_delete_form.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/_delete_form.html.twig
@@ -1,0 +1,4 @@
+<form method="post" action="{{ path('app_white_label_employe_delete', {'id': employe.id}) }}" onsubmit="return confirm('Are you sure you want to delete this item?');">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ employe.id) }}">
+    <button class="btn btn-danger px-5 rounded-pill"><i class="bi me-2 bi-trash"></i>Supprimer</button>
+</form>

--- a/templates/white_label/client1/admin/finance_employe/_form.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/_form.html.twig
@@ -1,0 +1,4 @@
+{{ form_start(form, {'attr': {'class': 'white-label-form'}}) }}
+    {{ form_widget(form) }}
+    <button class="btn btn-primary px-5 rounded-pill"><i class="bi me-2 bi-save"></i>{{ button_label|default('Save') }}</button>
+{{ form_end(form) }}

--- a/templates/white_label/client1/admin/finance_employe/edit.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/edit.html.twig
@@ -1,0 +1,21 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Modifier employé{% endblock %}
+{% block page_title %}Modifier employé{% endblock %}
+
+
+{% block body %}
+<section class="p-0 m-0">
+    <div class="container">
+        <div class="row p-4 pb-0 pe-lg-0 pt-lg-5 align-items-center">
+            <h1 class="h3">Modifier employé</h1>
+
+            {{ include('white_label/client1/admin/finance_employe/_form.html.twig', {'button_label': 'Update'}) }}
+
+            <div class="d-flex justify-content-end w-100">
+                {{ include('white_label/client1/admin/finance_employe/_delete_form.html.twig') }}
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/white_label/client1/admin/finance_employe/index.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/index.html.twig
@@ -1,0 +1,48 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Tous les employés{% endblock %}
+{% block page_title %}Tous les employés{% endblock %}
+
+
+{% block body %}
+
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Tous les employés</h1>
+    <div>
+        <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_employe_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>
+    </div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>{{ knp_pagination_sortable(employes, 'ID', 'e.id') }}</th>
+                <th>Nom et prénom(s)</th>
+                <th class="text-center">{{ knp_pagination_sortable(employes, 'Simulations', 'simCount') }}</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for employe in employes %}
+            <tr>
+                <td>{{ employe.id }}</td>
+                <td>{{ employe.user.fullName }}</td>
+                <td class="text-center">{{ employe.simCount|default(employe.simulateurs|length) }}</td>
+                <td>
+                    <a class="btn btn-sm rounded-cirle btn-info" href="{{ path('app_white_label_employe_show', {'id': employe.id}) }}"><i class="bi bi-eye"></i></a>
+                    <a class="btn btn-sm rounded-cirle btn-danger" href="{{ path('app_white_label_employe_edit', {'id': employe.id}) }}"><i class="bi bi-pencil"></i></a>
+                </td>
+            </tr>
+        {% else %}
+            <tr>
+                <td colspan="12">Aucun employé trouvé</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {{ knp_pagination_render(employes) }}
+</div>
+
+{% endblock %}

--- a/templates/white_label/client1/admin/finance_employe/new.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/new.html.twig
@@ -1,0 +1,17 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Nouvel employé{% endblock %}
+{% block page_title %}Nouvel employé{% endblock %}
+
+
+{% block body %}
+<section class="p-0 m-0">
+    <div class="container">
+        <div class="row p-4 pb-0 pe-lg-0 pt-lg-5 align-items-center">
+            <h1 class="h3">Créer un employé</h1>
+
+            {{ include('white_label/client1/admin/finance_employe/_form.html.twig') }}
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/white_label/client1/admin/finance_employe/show.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/show.html.twig
@@ -1,0 +1,41 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Employé #{{ employe.id }}{% endblock %}
+{% block page_title %}Employé #{{ employe.id }}{% endblock %}
+
+
+{% block body %}
+<section class="p-0 m-0">
+    <div class="container">
+        <div class="row p-4 pb-0 pe-lg-0 pt-lg-5 align-items-center">
+            <h1 class="h3">{{ employe.user.fullName }} </h1>
+
+            <table class="table">
+                <tbody>
+                    <tr>
+                        <th class="col-3">Email</th>
+                        <td>{{ employe.user.email }}</td>
+                    </tr>
+                    <tr>
+                        <th class="col-3">Téléphone</th>
+                        <td>{{ employe.user.telephone }}</td>
+                    </tr>
+                    <tr>
+                        <th class="col-3">Date d'embauche</th>
+                        <td>{{ employe.dateEmbauche ? employe.dateEmbauche|date('d/m/Y') : '' }}</td>
+                    </tr>
+                    <tr>
+                        <th class="col-3">Simulations</th>
+                        <td>{{ employe.getSimulateurCount() }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="d-flex justify-content-end w-100">
+                <a class="btn btn-secondary px-5 rounded-pill" href="{{ path('app_white_label_employe_edit', {'id': employe.id}) }}"><i class="bi me-2 bi-pencil"></i>Modifier</a>
+                {{ include('white_label/client1/admin/finance_employe/_delete_form.html.twig') }}
+            </div>
+        </div>
+    </div>
+</section>
+
+{% endblock %}

--- a/templates/white_label/client1/layout/admin.html.twig
+++ b/templates/white_label/client1/layout/admin.html.twig
@@ -39,6 +39,11 @@
         </a>
       </li>
       <li class="nav-item">
+        <a href="{{ path('app_white_label_employe_index')}}" class="nav-link {{ current_route == 'app_white_label_employe_index' ? 'underline' : '' }}" aria-current="page">
+        <i class="mx-2 h5 bi bi-briefcase"></i><span class="sidebar-text">Employés</span>
+        </a>
+      </li>
+      <li class="nav-item">
         <a href="{{ path('app_white_label_job_listing_index')}}" class="nav-link {{ (current_route == 'app_white_label_job_listing_index' or current_route == 'app_tableau_de_bord_candidat_view_job_offer' or current_route == 'app_olona_talents_prestations') ? 'underline' : '' }}" aria-current="page">
         <i class="mx-2 h5 bi bi-megaphone"></i><span class="sidebar-text">Annonces</span>
         </a>


### PR DESCRIPTION
## Summary
- add pagination helper for Employee repository
- expose new EmployeController for white label admin
- update ReferreProfileController base route
- create twig templates for employee management
- add navigation link to sidebar

## Testing
- `php bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862590f6fdc83309af5030c77d8b5c2