### PR TITLE
Activate PrimeAnnonce in white label only

### DIFF
--- a/src/WhiteLabel/Controller/Client1/RecruiterController.php
+++ b/src/WhiteLabel/Controller/Client1/RecruiterController.php
@@ -101,7 +101,9 @@ class RecruiterController extends AbstractController
         }
 
         $jobListing = $jobListingManager->init($entreprise);
-        $form = $this->createForm(\App\WhiteLabel\Form\Client1\JobListing1Type::class, $jobListing);
+        $defaultDevise = $this->entityManager->getRepository(\App\WhiteLabel\Entity\Client1\Finance\Devise::class)->findOneBy(['slug' => 'ariary']);
+        $devise = $entreprise->getDevise() instanceof \App\WhiteLabel\Entity\Client1\Finance\Devise ? $entreprise->getDevise() : $defaultDevise;
+        $form = $this->createForm(\App\WhiteLabel\Form\Client1\JobListing1Type::class, $jobListing, ['default_devise' => $devise]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/WhiteLabel/Form/Client1/BudgetAnnonceType.php
+++ b/src/WhiteLabel/Form/Client1/BudgetAnnonceType.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1;
+
+use App\WhiteLabel\Entity\Client1\Finance\Devise;
+use App\WhiteLabel\Entity\Client1\Entreprise\BudgetAnnonce;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+class BudgetAnnonceType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('typeBudget', ChoiceType::class, [
+                'choices' => BudgetAnnonce::arrayTarifType(),
+                'label' => false,
+            ])
+            ->add('montant', IntegerType::class,[
+                'label' => false,
+                'attr' => [
+                    'class' => '',
+                ],
+            ])
+            ->add('currency', EntityType::class, [
+                'label' => false,
+                'mapped' => true,
+                'class' => Devise::class,
+                'attr' => [
+                    'data-controller' => 'budget-taux',
+                    'data-action' => 'change->budget-taux#onDeviseChange'
+                ],
+            ])
+            ->add('taux', HiddenType::class, [
+                'attr' =>  [
+                    'data-id' => 'budgetAnnonce_taux',
+                    'value' => $options['default_devise'] ? $options['default_devise']->getTaux() : null,
+                ],
+                'data' => $options['default_devise'] ? $options['default_devise']->getTaux() : '4000',
+            ])
+            ->add('devise', HiddenType::class, [
+                'attr' =>  [
+                    'data-id' => 'budgetAnnonce_symbole',
+                ],
+                'data' => '€',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => BudgetAnnonce::class,
+            'default_devise' => null,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/JobListing1Type.php
+++ b/src/WhiteLabel/Form/Client1/JobListing1Type.php
@@ -10,7 +10,8 @@ use Doctrine\Persistence\ManagerRegistry;
 use App\WhiteLabel\Entity\Client1\Secteur;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-// use App\Form\Entreprise\BudgetAnnonceType;
+use App\WhiteLabel\Form\Client1\PrimeAnnonceType;
+use App\WhiteLabel\Form\Client1\BudgetAnnonceType;
 use Symfony\Component\Validator\Constraints\Length;
 use App\WhiteLabel\Entity\Client1\EntrepriseProfile;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -164,17 +165,14 @@ class JobListing1Type extends AbstractType
                 'no_results_found_text' => 'Aucun résultat' ,
                 'no_more_results_text' => 'Plus de résultats' ,
             ])
-            // ->add('budgetAnnonce', BudgetAnnonceType::class, [
-            //     'label' => 'Budget prévu pour la mission',
-            //     'required' => false,
-            //     'label_attr' => [
-            //         'class' => 'fw-bold fs-6' 
-            //     ],
-            //     'constraints' => new Sequentially([
-            //         new NotBlank(message:'Champ obligatoire.'),
-            //     ]),
-            //     'help' => 'Définissez le budget alloué pour cette annonce ou mission.'
-            // ])
+            ->add('primeAnnonce', \App\WhiteLabel\Form\Client1\PrimeAnnonceType::class, [
+                'label' => false,
+                'default_devise' => $options['default_devise'] ?? null
+            ])
+            ->add('budgetAnnonce', \App\WhiteLabel\Form\Client1\BudgetAnnonceType::class, [
+                'label' => false,
+                'default_devise' => $options['default_devise'] ?? null
+            ])
             // ->add('boost', EntityType::class, [
             //     'class' => Boost::class,
             //     'choice_label' => 'id',
@@ -232,6 +230,7 @@ class JobListing1Type extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => JobListing::class,
+            'default_devise' => null,
         ]);
     }
 

--- a/src/WhiteLabel/Form/Client1/PrimeAnnonceType.php
+++ b/src/WhiteLabel/Form/Client1/PrimeAnnonceType.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\WhiteLabel\Form\Client1;
+
+use App\WhiteLabel\Entity\Client1\Finance\Devise;
+use App\WhiteLabel\Entity\Client1\Entreprise\PrimeAnnonce;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+class PrimeAnnonceType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('montant', IntegerType::class,[
+                'label' => false,
+                'required' => false,
+            ])
+            ->add('devise', EntityType::class, [
+                'label' => false,
+                'mapped' => true,
+                'class' => Devise::class,
+                'attr' => [
+                    'data-controller' => 'prime-taux',
+                    'data-action' => 'change->prime-taux#onDeviseChange'
+                ],
+            ])
+            ->add('taux', HiddenType::class, [
+                'attr' =>  [
+                    'data-id' => 'primeAnnonce_taux',
+                    'value' => $options['default_devise'] ? $options['default_devise']->getTaux() : null,
+                ]
+            ])
+            ->add('symbole', HiddenType::class, [
+                'attr' =>  [
+                    'data-id' => 'primeAnnonce_symbole',
+                ],
+                'data' => '€',
+            ])
+        ;
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $form = $event->getForm();
+            $devise = $form->get('devise')->getData();
+
+            if ($devise) {
+                $taux = $form->get('taux')->getData();
+                $form->get('taux')->setData($taux);
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => PrimeAnnonce::class,
+            'default_devise' => null,
+        ]);
+    }
+}

--- a/src/WhiteLabel/Manager/Client1/JobListingManager.php
+++ b/src/WhiteLabel/Manager/Client1/JobListingManager.php
@@ -8,6 +8,9 @@ use App\WhiteLabel\Entity\Client1\Logs\ActivityLog;
 use App\WhiteLabel\Entity\Client1\Vues\AnnonceVues;
 use App\WhiteLabel\Entity\Client1\EntrepriseProfile;
 use App\WhiteLabel\Entity\Client1\Entreprise\JobListing;
+use App\WhiteLabel\Entity\Client1\Entreprise\BudgetAnnonce;
+use App\WhiteLabel\Entity\Client1\Entreprise\PrimeAnnonce;
+use App\WhiteLabel\Entity\Client1\Finance\Devise;
 use App\WhiteLabel\Entity\Client1\Candidate\Applications;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Form\Form;
@@ -25,14 +28,40 @@ class JobListingManager
 
     public function init(EntrepriseProfile $recruiter): JobListing
     {
+        $defaultDevise = $this->entityManager->getRepository(Devise::class)->findOneBy(['slug' => 'ariary']);
+        $devise = $recruiter->getDevise() instanceof Devise ? $recruiter->getDevise() : $defaultDevise;
+        $budget = $this->initBudgetAnnonce($devise);
+        $primeAnnonce = $this->initPrimeAnnonce($devise);
+
         $jobListing = new JobListing();
         $jobListing->setDateCreation(new \DateTime());
         $jobListing->setStatus(JobListing::STATUS_PENDING);
         $jobListing->setIsGenerated(false);
         $jobListing->setJobId(new Uuid(Uuid::v1()));
         $jobListing->setEntreprise($recruiter);
+        $jobListing->setBudgetAnnonce($budget);
+        $jobListing->setPrimeAnnonce($primeAnnonce);
 
         return $jobListing;
+    }
+
+    public function initPrimeAnnonce(Devise $devise): PrimeAnnonce
+    {
+        $primeAnnonce = new PrimeAnnonce();
+        $primeAnnonce->setCreatedAt(new \DateTime());
+        $primeAnnonce->setDevise($devise);
+        $primeAnnonce->setSymbole($devise->getSymbole());
+        $primeAnnonce->setTaux($devise->getTaux());
+
+        return $primeAnnonce;
+    }
+
+    public function initBudgetAnnonce(Devise $devise): BudgetAnnonce
+    {
+        $budget = new BudgetAnnonce();
+        $budget->setCurrency($devise);
+
+        return $budget;
     }
 
     public function save(JobListing $jobListing)

--- a/src/WhiteLabel/Security/Voter/JobListingVoter.php
+++ b/src/WhiteLabel/Security/Voter/JobListingVoter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\WhiteLabel\Security\Voter;
+
+use App\WhiteLabel\Entity\Client1\Entreprise\JobListing;
+use App\WhiteLabel\Entity\Client1\User;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class JobListingVoter extends Voter
+{
+    public const EDIT = 'JOB_LISTING_EDIT';
+    public const VIEW = 'JOB_LISTING_VIEW';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [self::EDIT, self::VIEW])
+            && $subject instanceof JobListing;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        if (!$subject instanceof JobListing) {
+            return false;
+        }
+
+        switch ($attribute) {
+            case self::EDIT:
+                if (in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+                    return true;
+                }
+                return $subject->getEntreprise()->getId() === $user->getEntrepriseProfile()->getId();
+            case self::VIEW:
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
+++ b/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
@@ -43,6 +43,54 @@
             <div class="row">
                 {{ form_row(form.description) }}
             </div>
+            <div class="row mt-3">
+                {{ form_label(form.primeAnnonce, null, {
+                    'label_attr': {
+                        'class': 'fw-bold fs-6'
+                    }
+                }) }}
+                <div class="row">
+                    <div class="col-6">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Montant</label>
+                            {{ form_widget(form.primeAnnonce.montant) }}
+                        </div>
+                    </div>
+                    <div class="col-6">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Devise</label>
+                            {{ form_widget(form.primeAnnonce.devise) }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row mt-3">
+                {{ form_label(form.budgetAnnonce, null, {
+                    'label_attr': {
+                        'class': 'fw-bold fs-6'
+                    }
+                }) }}
+                <div class="row">
+                    <div class="col-4">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Type</label>
+                            {{ form_widget(form.budgetAnnonce.typeBudget) }}
+                        </div>
+                    </div>
+                    <div class="col-4">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Montant</label>
+                            {{ form_widget(form.budgetAnnonce.montant)}}
+                        </div>
+                    </div>
+                    <div class="col-4">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Devise</label>
+                            {{ form_widget(form.budgetAnnonce.currency)}}
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="row">
                 <div class="col">
                     <div style="display:none;">


### PR DESCRIPTION
## Summary
- restrict prime fields to white label
- initialize prime and budget for client1 job listings
- expose prime fields in client1 recruiter form
- ensure referrals record prime amounts
- revert prime fields from standard dashboard
- add white label job listing voter

## Testing
- `phpunit -c phpunit.xml.dist --testsuite default` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686287978fc48330bdcc965ffe2b2494