### PR TITLE
Enable Turbo for white-label favorites

### DIFF
--- a/src/WhiteLabel/Controller/Client1/Ajax/FavoriteController.php
+++ b/src/WhiteLabel/Controller/Client1/Ajax/FavoriteController.php
@@ -13,6 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\UX\Turbo\TurboBundle;
 
 #[Route('/ajax')]
 class FavoriteController extends AbstractController
@@ -67,7 +68,18 @@ class FavoriteController extends AbstractController
         $this->entityManager->persist($favori);
         $this->entityManager->flush();
 
-        return $this->json(['message' => 'Candidat ajouté aux favoris avec succès'], Response::HTTP_CREATED);
+        $message = 'Candidat ajouté aux favoris avec succès';
+
+        if ($request->getPreferredFormat() === TurboBundle::STREAM_FORMAT) {
+            $request->setRequestFormat(TurboBundle::STREAM_FORMAT);
+
+            return $this->render('white_label/client1/recruiter/favorite/update.html.twig', [
+                'favoriteId' => $candidat->getId(),
+                'message' => $message,
+            ]);
+        }
+
+        return $this->json(['message' => $message], Response::HTTP_CREATED);
     }
 
     #[Route('/favorite/delete/candidate/{id}', name: 'app_white_label_client1_favorite_delete_candidate', methods: ['POST'])]
@@ -96,8 +108,21 @@ class FavoriteController extends AbstractController
         $favori = $favorisRepository->findOneBy($criteria);
 
         if ($favori) {
+            $favoriteId = $favori->getId();
             $this->entityManager->remove($favori);
             $this->entityManager->flush();
+
+            $message = 'Candidat retiré des favoris avec succès';
+
+            if ($request->getPreferredFormat() === TurboBundle::STREAM_FORMAT) {
+                $request->setRequestFormat(TurboBundle::STREAM_FORMAT);
+
+                return $this->render('white_label/client1/recruiter/favorite/delete.html.twig', [
+                    'favoriteId' => $favoriteId,
+                    'candidateId' => $candidat->getId(),
+                    'message' => $message,
+                ]);
+            }
         }
 
         return $this->json(['message' => 'Candidat retiré des favoris avec succès'], Response::HTTP_OK);

--- a/templates/white_label/client1/recruiter/favoris.html.twig
+++ b/templates/white_label/client1/recruiter/favoris.html.twig
@@ -7,24 +7,53 @@
 <section class="recruteur-container">
     <div class="recruteur-block d-block p-4 mb-4">
         <h1>Liste des favoris</h1>
+        {% set tableClass = 'table' %}
+        {% if app.request.cookies.get('theme') == 'bootstrap-dark' %}
+            {% set tableClass = tableClass ~ ' table-dark' %}
+        {% endif %}
         {% if favoris|length > 0 %}
-            <div class="biographie-profil-list">
-                {% for item in favoris %}
-                    {% set favori = item[0] %}
-                    <div class="profil-list-item d-md-flex align-items-center justify-content-between mb-3">
-                        <div class="profil-list-name d-flex align-items-center">
-                            <span class="profil-photo_"><img src="{{ favori.candidat.fileName ? asset('uploads/experts/' ~ favori.candidat.fileName) : asset('v2/images/dashboard/.svg')}}" alt=""></span>
-                            <div class="profil-info_">
-                                <span class="profil-titire_">{{ favori.candidat.titre }}</span>
-                            </div>
-                        </div>
-                        <div class="profil-list-link d-flex align-items-center">
-                            <a class="btn btn-outline text-primary" href="{{ path('app_white_label_client1_recruiter_view_profile', {'id': favori.candidat.id}) }}">Voir son profil</a>
-                        </div>
-                    </div>
-                {% endfor %}
+            <div class="table-responsive mt-4">
+                <table class="{{ tableClass }}">
+                    <thead>
+                        <tr>
+                            <th>Matricule</th>
+                            <th class="text-center">Tarif</th>
+                            <th class="text-center">Disponibilité</th>
+                            <th class="text-center"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in favoris %}
+                            {% set favori = item[0] %}
+                            <tr id="row_favorite_recruiter_{{ favori.id }}">
+                                <td>
+                                    <div class="d-flex align-items-center">
+                                        <span class="me-2 rounded-circle" style="width:40px;height:40px;background-image:url('{{ favori.candidat.fileName ? asset('uploads/experts/' ~ favori.candidat.fileName) : asset('uploads/experts/avatar-default.jpg') }}');background-size:cover;background-position:center"></span>
+                                        <div>
+                                            {{ generatePseudo(favori.candidat) }}<br>
+                                            <span class="fw-light">{{ favori.candidat.titre }}</span>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="text-center">
+                                    <span class="small fw-bold">{{ getDefaultTarifCandidat(favori.candidat) }}</span><br>
+                                    <span class="fw-lighter small">Ajouté le {{ favori.createdAt|date('d/m/Y') }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <span class="fw-lighter small">{{ getAvailabilityStr(favori.candidat) }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <a class="btn btn-sm btn-secondary" href="{{ path('app_white_label_client1_recruiter_view_profile', {'id': favori.candidat.id}) }}"><i class="bi bi-eye"></i></a>
+                                    <form action="{{ path('app_white_label_client1_favorite_delete_candidate', {'id': favori.candidat.id}) }}" method="post" id="delete-favorite" class="d-inline-block">
+                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {{ knp_pagination_render(favoris) }}
             </div>
-            {{ knp_pagination_render(favoris) }}
         {% else %}
             <p>Aucun favori.</p>
         {% endif %}

--- a/templates/white_label/client1/recruiter/favorite/delete.html.twig
+++ b/templates/white_label/client1/recruiter/favorite/delete.html.twig
@@ -1,0 +1,16 @@
+<turbo-stream action="remove" target="row_favorite_recruiter_{{favoriteId}}"></turbo-stream>
+<turbo-stream action="append" target="flash">
+  <template>
+    <div class="alert alert-success">{{ message }}</div>
+  </template>
+</turbo-stream>
+<turbo-stream action="update" target="row_favorite_{{candidateId}}">
+  <template>
+    <button type="button" class="btn btn-primary text-primary add-to-favorites" data-href="{{ path('app_white_label_client1_favorite_add_candidate', {'id':candidateId}) }}"><i class="bi bi-star me-2"></i>Ajouter à mes favoris</button>
+  </template>
+</turbo-stream>
+<turbo-stream action="update" target="row_star_favorite_{{candidateId}}">
+  <template>
+    <i class="bi bi-star"></i>
+  </template>
+</turbo-stream>

--- a/templates/white_label/client1/recruiter/favorite/update.html.twig
+++ b/templates/white_label/client1/recruiter/favorite/update.html.twig
@@ -1,0 +1,11 @@
+<turbo-stream action="update" target="row_favorite_{{favoriteId}}">
+  <template>
+    <button type="button" class="btn btn-info remove-from-favorites" data-href="{{ path('app_white_label_client1_favorite_delete_candidate', {'id':favoriteId}) }}"><i class="bi bi-star-fill me-2"></i>Effacer de mes favoris</button>
+  </template>
+</turbo-stream>
+
+<turbo-stream action="update" target="row_star_favorite_{{favoriteId}}">
+  <template>
+    <i class="bi bi-star-fill"></i>
+  </template>
+</turbo-stream>


### PR DESCRIPTION
## Summary
- enable Turbo stream responses in white label favorites controller
- add turbo templates for add/remove actions
- display recruiter favorites list in a table layout

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ec0310508330b876929e1cad301e