### PR TITLE
Add image support for white label job listings

### DIFF
--- a/config/packages/vich_uploader.yaml
+++ b/config/packages/vich_uploader.yaml
@@ -23,6 +23,13 @@ vich_uploader:
            delete_on_update: false
            delete_on_remove: false
 
+       job_listing_image:
+           uri_prefix: '%job_listing_image%'
+           upload_destination: '%kernel.project_dir%/public%job_listing_image%'
+           namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
+           delete_on_update: false
+           delete_on_remove: false
+
        products:
            uri_prefix: /images/products
            upload_destination: '%kernel.project_dir%/public/images/products'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ parameters:
     cv_expert: /uploads/experts
     medias_prestation: /uploads/prestations
     logo_company: /uploads/compagnies
+    job_listing_image: /uploads/annonces
     white_label.client1.host: ['client1.olona-talents.local.com:8000', 'client1.olona-talents.com']
     app.main.host: ['localhost:8000', '127.0.0.1:8000', 'dev.olona-talents.com', 'olona-talents.com']
     white_label.client1.host_regex: '/^(client1\.olona-talents\.local\.com|client1\.olona-talents\.com)$/'

--- a/src/WhiteLabel/Entity/Client1/Entreprise/JobListing.php
+++ b/src/WhiteLabel/Entity/Client1/Entreprise/JobListing.php
@@ -16,8 +16,11 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\HttpFoundation\File\File;
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[ORM\Entity(repositoryClass: JobListingRepository::class)]
+#[Vich\Uploadable]
 class JobListing
 {
     const STATUS_DRAFT = 'DRAFT';
@@ -145,6 +148,12 @@ class JobListing
     #[ORM\Column(nullable: true)]
     #[Groups(['annonce'])]
     private ?int $nombrePoste = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $imageName = null;
+
+    #[Vich\UploadableField(mapping: 'job_listing_image', fileNameProperty: 'imageName')]
+    private ?File $imageFile = null;
 
     #[ORM\OneToMany(mappedBy: 'annonce', targetEntity: Referral::class)]
     private Collection $referrals;
@@ -431,6 +440,32 @@ class JobListing
     public function setNombrePoste(?int $nombrePoste): static
     {
         $this->nombrePoste = $nombrePoste;
+
+        return $this;
+    }
+
+    public function setImageFile(?File $imageFile = null): void
+    {
+        $this->imageFile = $imageFile;
+
+        if (null !== $imageFile) {
+            $this->updatedAt = new \DateTime();
+        }
+    }
+
+    public function getImageFile(): ?File
+    {
+        return $this->imageFile;
+    }
+
+    public function getImageName(): ?string
+    {
+        return $this->imageName;
+    }
+
+    public function setImageName(?string $imageName): static
+    {
+        $this->imageName = $imageName;
 
         return $this;
     }

--- a/src/WhiteLabel/Form/Client1/JobListing1Type.php
+++ b/src/WhiteLabel/Form/Client1/JobListing1Type.php
@@ -24,6 +24,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Validator\Constraints\File;
 use App\WhiteLabel\Form\Client1\DataTransformer\CompetencesTransformer;
 
 class JobListing1Type extends AbstractType
@@ -75,6 +77,21 @@ class JobListing1Type extends AbstractType
                     'rows' => 6,
                     'class' => 'ckeditor-textarea'
                 ]
+            ])
+            ->add('imageFile', FileType::class, [
+                'required' => false,
+                'label' => 'Image',
+                'constraints' => [
+                    new File([
+                        'maxSize' => '2048k',
+                        'mimeTypes' => [
+                            'image/jpeg',
+                            'image/png',
+                            'image/jpg',
+                            'image/bmp',
+                        ],
+                    ])
+                ],
             ])
             ->add('dateExpiration', DateType::class, [
                 'label' => 'Date d\'expiration',

--- a/templates/white_label/client1/home/annonce.html.twig
+++ b/templates/white_label/client1/home/annonce.html.twig
@@ -92,7 +92,7 @@
                         <div class="view-job-info">
                             <div class="view-job-top">
                                 <div class="view_media-bg">
-                                    <img src="{{ asset('v2/images/dashboard/fond_annonce_entreprise.webp')}}" class="img-fluid" alt="Societe">
+                                    <img src="{{ jobOffer.imageName ? vich_uploader_asset(jobOffer, 'imageFile') : asset('v2/images/dashboard/fond_annonce_entreprise.webp') }}" class="img-fluid" alt="Societe">
                                     <div class="view_jobs-category green"><span class="view_bg-green">Annonce</span></div>
                                 </div>
                                 <div class="view_mid-content">

--- a/templates/white_label/client1/home/annonce_view.html.twig
+++ b/templates/white_label/client1/home/annonce_view.html.twig
@@ -7,6 +7,9 @@
     <div class="container">
         <div class="annonce-list p-2">
             <div class="annonce-item shadow p-4 m-4">
+                <div class="mb-3 text-center">
+                    <img src="{{ annonce.imageName ? vich_uploader_asset(annonce, 'imageFile') : asset('v2/images/dashboard/fond_annonce_entreprise.webp') }}" class="img-fluid" alt="Annonce">
+                </div>
                 <h1 class="card-title h2">{{ annonce.titre }}</h1>
                 <p class="text-muted small">
                     <i class="bi bi-circle-fill small mx-2 text-danger"></i> {{ getStatuses(annonce.status) }} 

--- a/templates/white_label/client1/user/annonce.html.twig
+++ b/templates/white_label/client1/user/annonce.html.twig
@@ -20,7 +20,7 @@
                         <div class="view-job-info">
                             <div class="view-job-top">
                                 <div class="view_media-bg">
-                                    <img src="{{ asset('v2/images/dashboard/fond_annonce_entreprise.webp')}}" class="img-fluid" alt="Societe">
+                                    <img src="{{ jobOffer.imageName ? vich_uploader_asset(jobOffer, 'imageFile') : asset('v2/images/dashboard/fond_annonce_entreprise.webp') }}" class="img-fluid" alt="Societe">
                                     <div class="view_jobs-category green"><span class="view_bg-green">Annonce</span></div>
                                 </div>
                                 <div class="view_mid-content">


### PR DESCRIPTION
## Summary
- configure new `job_listing_image` path for uploads
- allow uploading an image in white label job listings
- expose image field in JobListing1Type form
- show the uploaded image on job listing detail pages

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c6490b3c8330b4d67cf0dc407eaa