### PR TITLE
Add image upload to recruiter job ad form

### DIFF
--- a/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
+++ b/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
@@ -43,6 +43,14 @@
             <div class="row">
                 {{ form_row(form.description) }}
             </div>
+            <div class="row mb-3">
+                <div class="col-lg-6 col-sm-12">
+                    {{ form_row(form.imageFile) }}
+                </div>
+                <div class="col-lg-6 col-sm-12">
+                    <div id="imagePreview" style="width:100%;height:200px;background-image:url('{{ form.vars.data.imageName ? asset('uploads/annonces/' ~ form.vars.data.imageName) : asset('images/annonce.png') }}');background-size:cover;background-position:center;"></div>
+                </div>
+            </div>
             <div class="row mt-3">
                 {{ form_label(form.primeAnnonce, null, {
                     'label_attr': {
@@ -103,4 +111,15 @@
                 </div>
             </div>
             {{ form_end(form) }}
+            <script>
+                document.getElementById('{{ form.imageFile.vars.id }}').addEventListener('change', function(event) {
+                    if (event.target.files && event.target.files[0]) {
+                        var reader = new FileReader();
+                        reader.onload = function(e) {
+                            document.getElementById('imagePreview').style.backgroundImage = 'url(' + e.target.result + ')';
+                        };
+                        reader.readAsDataURL(event.target.files[0]);
+                    }
+                });
+            </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable job image upload in white label recruiter job form
- show preview div and JS to update preview

## Testing
- `php -d detect_unicode=0 vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e915943c8330917e9ea68b61abeb