### PR TITLE
Add white label job offer editing

### DIFF
--- a/templates/white_label/client1/recruiter/modifier_une_annonce.html.twig
+++ b/templates/white_label/client1/recruiter/modifier_une_annonce.html.twig
@@ -1,0 +1,125 @@
+{% extends 'white_label/client1/base.html.twig' %}
+
+{% block title %}Modifier une annonce{% endblock %}
+{% block page_title %}Modifier une annonce{% endblock %}
+
+{% block body %}
+        <div class="offre-emploi-item">
+            <div>
+                <h1>Modifiez votre offre et recrutez les meilleurs talents</h1>
+                <p>Décrivez votre poste, les compétences recherchées, le type de contrat et le lieu.</p>
+            </div>
+        </div>
+        <div id="jobListingForm">
+            {{ form_start(form, {'attr': {'id': 'editJob', 'class': 'white-label-form'}}) }}
+            <div class="row">
+                <div class="col">
+                    <div class="mb-3">
+                        {{ form_row(form.titre) }}
+                        <div class="row">
+                            <div class="col">
+                                {{ form_row(form.secteur) }}
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.lieu) }}
+                            </div>
+                            <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.nombrePoste) }}
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.competences) }}
+                            </div>
+                            <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.dateExpiration) }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                {{ form_row(form.description) }}
+            </div>
+            <div class="row mb-3">
+                <div class="col-lg-6 col-sm-12">
+                    {{ form_row(form.imageFile) }}
+                </div>
+                <div class="col-lg-6 col-sm-12">
+                    <div id="imagePreview" style="width:100%;height:200px;background-image:url('{{ form.vars.data.imageName ? asset('wl/client1/annonces/' ~ form.vars.data.imageName) : asset('v2/images/dashboard/fond_annonce_entreprise.webp') }}');background-size:cover;background-position:center;"></div>
+                </div>
+            </div>
+            <div class="row mt-3">
+                {{ form_label(form.primeAnnonce, null, {
+                    'label_attr': {
+                        'class': 'fw-bold fs-6'
+                    }
+                }) }}
+                <div class="row">
+                    <div class="col-6">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Montant</label>
+                            {{ form_widget(form.primeAnnonce.montant) }}
+                        </div>
+                    </div>
+                    <div class="col-6">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Devise</label>
+                            {{ form_widget(form.primeAnnonce.devise) }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row mt-3">
+                {{ form_label(form.budgetAnnonce, null, {
+                    'label_attr': {
+                        'class': 'fw-bold fs-6'
+                    }
+                }) }}
+                <div class="row">
+                    <div class="col-4">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Type</label>
+                            {{ form_widget(form.budgetAnnonce.typeBudget) }}
+                        </div>
+                    </div>
+                    <div class="col-4">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Montant</label>
+                            {{ form_widget(form.budgetAnnonce.montant)}}
+                        </div>
+                    </div>
+                    <div class="col-4">
+                        <div class="mb-3">
+                            <label class="fw-bold small">Devise</label>
+                            {{ form_widget(form.budgetAnnonce.currency)}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <div style="display:none;">
+                        {{ form_widget(form) }}
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-lg my-3 my-sm-4 fs-6 px-4 px-sm-5 fw-semibold text-uppercase">
+                        <i class="bi bi-save"></i>
+                        Enregistrer
+                    </button>
+                </div>
+            </div>
+            {{ form_end(form) }}
+            <script>
+                document.getElementById('{{ form.imageFile.vars.id }}').addEventListener('change', function(event) {
+                    if (event.target.files && event.target.files[0]) {
+                        var reader = new FileReader();
+                        reader.onload = function(e) {
+                            document.getElementById('imagePreview').style.backgroundImage = 'url(' + e.target.result + ')';
+                        };
+                        reader.readAsDataURL(event.target.files[0]);
+                    }
+                });
+            </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow recruiters to edit job offers in white label client1
- include voter check for editing permissions
- add template for modifying an offer

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865160071f88330a15d4d2746f35e87