### PR TITLE
Add BOA Madagascar agency location fields

### DIFF
--- a/src/EventSubscriber/RegionAgenceSubscriber.php
+++ b/src/EventSubscriber/RegionAgenceSubscriber.php
@@ -1,0 +1,164 @@
+<?php
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+class RegionAgenceSubscriber implements EventSubscriberInterface
+{
+    private const AGENCIES_BY_REGION = [
+        'DIANA' => [
+            'Antsiranana',
+            'Nosy-Be',
+            'Ambanja',
+            'Ambilobe',
+            'Tanambao',
+        ],
+        'SAVA' => [
+            'Sambava',
+            'Antalaha',
+            'Vohémar',
+            'Andapa',
+        ],
+        'Itasy' => [
+            'Miarinarivo',
+            'Arivonimamo',
+        ],
+        'Analamanga' => [
+            'Antsahavola',
+            'Ambohibao',
+            'Ankadimbahoaka',
+            'Ankorondrano',
+            'Ambatobe',
+            'Andraharo',
+            'Behoririka',
+            'Ampasampito',
+            'Analamahitsy',
+            'Itaosy',
+            'Tsimbazaza',
+            'Ivandry',
+            'Andavamamba',
+            'Mahitsy',
+            'Andravoahangy',
+            'Mahazo',
+            'Ivato',
+            'Anosizato',
+            'Sabotsy Namehana',
+        ],
+        'Vakinankaratra' => [
+            'Antsirabe',
+            'Ambatolampy',
+            'Betafo',
+            'Ambohimiandrisoa',
+        ],
+        'Bongolava' => [
+            'Tsiroanomandidy',
+            'Analavory',
+        ],
+        'Sofia' => [
+            'Antsohihy',
+            'Port Bergé',
+            'Mampikony',
+        ],
+        'Boeny' => [
+            'Mahajanga',
+            'Tsaramandroso',
+            'Marovoay',
+            'Maevatanàna',
+            'Port Bergé',
+        ],
+        'Betsiboka' => [
+            'Maevatanana',
+        ],
+        'Melaky' => [
+            'Maintirano',
+        ],
+        'Alaotra-Mangoro' => [
+            'Ambatondrazaka',
+            'Moramanga',
+            'Amparafaravola',
+            'Tanambe',
+        ],
+        'Atsinanana' => [
+            'Toamasina',
+            'Fénérive-Est',
+            'Mahanoro',
+            'Brickaville',
+        ],
+        'Analanjirofo' => [
+            'Fénérive-Est',
+            'Maroantsetra',
+        ],
+        'Amoron\'i Mania' => [
+            'Ambositra',
+        ],
+        'Haute Matsiatra' => [
+            'Fianarantsoa',
+            'Ambalavao',
+            'Ambohimahasoa',
+        ],
+        'Vatovavy-Fitovinany' => [
+            'Manakara',
+            'Mananjary',
+        ],
+        'Atsimo-Atsinanana' => [
+            'Farafangana',
+            'Vangaindrano',
+        ],
+        'Ihorombe' => [
+            'Ihosy',
+        ],
+        'Menabe' => [
+            'Morondava',
+            'Miandrivazo',
+        ],
+        'Atsimo-Andrefana' => [
+            'Toliara',
+            'Ilakaka',
+            'Tanambao II',
+            'Morombe',
+            'Sakaraha',
+        ],
+        'Androy' => [
+            'Ambovombe',
+        ],
+        'Anosy' => [
+            'Tolagnaro',
+        ],
+    ];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FormEvents::PRE_SET_DATA => 'updateLieuField',
+            FormEvents::PRE_SUBMIT => 'updateLieuField',
+        ];
+    }
+
+    public function updateLieuField(FormEvent $event): void
+    {
+        $form = $event->getForm();
+        $data = $event->getData();
+
+        $region = null;
+
+        if (is_array($data)) {
+            $region = $data['region'] ?? null;
+        } elseif (is_object($data) && method_exists($data, 'getRegion')) {
+            $region = $data->getRegion();
+        }
+
+        $agencies = self::AGENCIES_BY_REGION[$region] ?? [];
+
+        $form->add('lieu', ChoiceType::class, [
+            'choices' => array_combine($agencies, $agencies),
+            'placeholder' => 'Sélectionnez une agence',
+            'required' => false,
+            'help' => 'Ce champ sera mis à jour automatiquement selon la région sélectionnée.',
+            'label' => 'Agence',
+            'label_attr' => ['class' => 'fw-bold fs-6'],
+        ]);
+    }
+}

--- a/src/WhiteLabel/Form/Client1/JobListing1Type.php
+++ b/src/WhiteLabel/Form/Client1/JobListing1Type.php
@@ -22,6 +22,7 @@ use App\WhiteLabel\Entity\Client1\Entreprise\JobListing;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Validator\Constraints\Sequentially;
+use App\EventSubscriber\RegionAgenceSubscriber;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -109,23 +110,44 @@ class JobListing1Type extends AbstractType
                 ],
                 'choices' => JobListing::getStatuses(),
             ])
-            ->add('lieu', ChoiceType::class, [
+            ->add('region', ChoiceType::class, [
                 'choices' => [
-                    'Remote' => 'Remote',
-                    'Local' => 'Local',
-                    'Télétravail' => 'Télétravail',
-                    'Coworking Olona Talents' => 'Coworking Olona Talents',
+                    'DIANA' => 'DIANA',
+                    'SAVA' => 'SAVA',
+                    'Itasy' => 'Itasy',
+                    'Analamanga' => 'Analamanga',
+                    'Vakinankaratra' => 'Vakinankaratra',
+                    'Bongolava' => 'Bongolava',
+                    'Sofia' => 'Sofia',
+                    'Boeny' => 'Boeny',
+                    'Betsiboka' => 'Betsiboka',
+                    'Melaky' => 'Melaky',
+                    'Alaotra-Mangoro' => 'Alaotra-Mangoro',
+                    'Atsinanana' => 'Atsinanana',
+                    'Analanjirofo' => 'Analanjirofo',
+                    "Amoron'i Mania" => "Amoron'i Mania",
+                    'Haute Matsiatra' => 'Haute Matsiatra',
+                    'Vatovavy-Fitovinany' => 'Vatovavy-Fitovinany',
+                    'Atsimo-Atsinanana' => 'Atsimo-Atsinanana',
+                    'Ihorombe' => 'Ihorombe',
+                    'Menabe' => 'Menabe',
+                    'Atsimo-Andrefana' => 'Atsimo-Andrefana',
+                    'Androy' => 'Androy',
+                    'Anosy' => 'Anosy',
                 ],
                 'required' => false,
-                'label' => 'Lieu',
+                'mapped' => false,
+                'label' => 'Région',
+                'placeholder' => 'Sélectionnez une région',
                 'label_attr' => [
-                    'class' => 'fw-bold fs-6' 
+                    'class' => 'fw-bold fs-6'
                 ],
                 'constraints' => new Sequentially([
                     new NotBlank(message:'Ce champ est obligatoires.'),
                 ]),
-                'help' => 'Indiquez le lieu de travail principal pour ce poste.'
+                'help' => 'Choisissez une région pour voir les agences disponibles.'
             ])
+            ->addEventSubscriber(new RegionAgenceSubscriber())
             ->add('nombrePoste', null, [
                 'label' => 'Nombre de personne à chercher',
                 'label_attr' => [

--- a/templates/white_label/client1/admin/job_listing/_form.html.twig
+++ b/templates/white_label/client1/admin/job_listing/_form.html.twig
@@ -12,6 +12,11 @@
     {{ form_row(form.dateExpiration)}}
     </div>
     <div class="col">
+    {{ form_row(form.region)}}
+    </div>
+</div>
+<div class="row">
+    <div class="col">
     {{ form_row(form.lieu)}}
     </div>
 </div>

--- a/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
+++ b/templates/white_label/client1/recruiter/creer_une_annonce.html.twig
@@ -23,8 +23,13 @@
                         </div>
                         <div class="row">
                             <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.region) }}
+                            </div>
+                            <div class="col-lg-6 col-sm-12">
                                 {{ form_row(form.lieu) }}
                             </div>
+                        </div>
+                        <div class="row">
                             <div class="col-lg-6 col-sm-12">
                                 {{ form_row(form.nombrePoste) }}
                             </div>

--- a/templates/white_label/client1/recruiter/modifier_une_annonce.html.twig
+++ b/templates/white_label/client1/recruiter/modifier_une_annonce.html.twig
@@ -23,8 +23,13 @@
                         </div>
                         <div class="row">
                             <div class="col-lg-6 col-sm-12">
+                                {{ form_row(form.region) }}
+                            </div>
+                            <div class="col-lg-6 col-sm-12">
                                 {{ form_row(form.lieu) }}
                             </div>
+                        </div>
+                        <div class="row">
                             <div class="col-lg-6 col-sm-12">
                                 {{ form_row(form.nombrePoste) }}
                             </div>


### PR DESCRIPTION
## Summary
- support region/agence location select for BOA Madagascar
- hook new RegionAgenceSubscriber to JobListing1Type
- display region and agency fields in white-label recruiter and admin forms

## Testing
- `composer test` *(fails: no tests defined)*
- `./vendor/bin/phpunit` *(fails: no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68669c8209e08330921149ec6e106d93