### PR TITLE
Add favorites info for recruiters

### DIFF
--- a/src/WhiteLabel/Controller/Client1/HomeController.php
+++ b/src/WhiteLabel/Controller/Client1/HomeController.php
@@ -131,8 +131,16 @@ class HomeController extends AbstractController
                     'form' => $form->createView(),
                 ]);
             }
+            $entreprise = $currentUser->getEntrepriseProfile();
+            $favorisList = [];
+            if ($entreprise && $annonce->getEntreprise()?->getId() === $entreprise->getId()) {
+                $favorisList = $this->entityManager->getRepository(\App\WhiteLabel\Entity\Client1\Entreprise\Favoris::class)
+                    ->findByAnnonce($annonce);
+            }
+
             return $this->render("white_label/client1/user/annonce.html.twig", [
                 'jobOffer' => $annonce,
+                'favorisList' => $favorisList,
             ]);
         }
         // if ($currentUser && $profile) {

--- a/src/WhiteLabel/Controller/Client1/RecruiterController.php
+++ b/src/WhiteLabel/Controller/Client1/RecruiterController.php
@@ -174,9 +174,20 @@ class RecruiterController extends AbstractController
             $paginatorInterface
         );
 
+        $annonceIds = [];
+        foreach ($offres as $item) {
+            $job = $item[0];
+            if ($job instanceof JobListing) {
+                $annonceIds[] = $job->getId();
+            }
+        }
+        $favorisCounts = $this->entityManager->getRepository(\App\WhiteLabel\Entity\Client1\Entreprise\Favoris::class)
+            ->countByAnnonces($annonceIds);
+
         return $this->render('white_label/client1/recruiter/annonces.html.twig', [
             'entreprise' => $entreprise,
             'offres' => $offres,
+            'favorisCounts' => $favorisCounts,
             'count' => $jobListingRepository->countAllByEntreprise($entreprise),
             'countStatus' => $jobListingRepository->countStatusByEntreprise($entreprise, $status),
             'statuses' => $jobListingManager->getStatuses(),

--- a/src/WhiteLabel/Repository/Client1/Entreprise/FavorisRepository.php
+++ b/src/WhiteLabel/Repository/Client1/Entreprise/FavorisRepository.php
@@ -4,6 +4,7 @@ namespace App\WhiteLabel\Repository\Client1\Entreprise;
 
 use App\WhiteLabel\Entity\Client1\Entreprise\Favoris;
 use App\WhiteLabel\Entity\Client1\EntrepriseProfile;
+use App\WhiteLabel\Entity\Client1\Entreprise\JobListing;
 use Doctrine\Persistence\ManagerRegistry;
 use Knp\Component\Pager\PaginatorInterface;
 use Knp\Component\Pager\Pagination\PaginationInterface;
@@ -39,5 +40,56 @@ class FavorisRepository extends ServiceEntityRepository
             10,
             []
         );
+    }
+
+    public function countByAnnonce(JobListing $annonce): int
+    {
+        return (int) $this->createQueryBuilder('f')
+            ->select('COUNT(f.id)')
+            ->andWhere('f.annonce = :annonce')
+            ->setParameter('annonce', $annonce)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @param int[] $annonceIds
+     * @return array<int,int> id => count
+     */
+    public function countByAnnonces(array $annonceIds): array
+    {
+        if (empty($annonceIds)) {
+            return [];
+        }
+
+        $results = $this->createQueryBuilder('f')
+            ->select('IDENTITY(f.annonce) AS annonceId, COUNT(f.id) AS favorisCount')
+            ->andWhere('f.annonce IN (:annonces)')
+            ->setParameter('annonces', $annonceIds)
+            ->groupBy('f.annonce')
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($results as $row) {
+            $counts[$row['annonceId']] = (int) $row['favorisCount'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return Favoris[]
+     */
+    public function findByAnnonce(JobListing $annonce): array
+    {
+        return $this->createQueryBuilder('f')
+            ->leftJoin('f.candidat', 'c')
+            ->addSelect('c')
+            ->andWhere('f.annonce = :annonce')
+            ->setParameter('annonce', $annonce)
+            ->orderBy('f.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/templates/white_label/client1/recruiter/annonces.html.twig
+++ b/templates/white_label/client1/recruiter/annonces.html.twig
@@ -53,7 +53,10 @@
                                     </div>
                                 </div>
                                 <div class="col-lg-4 mt-4">
-                                    <p><a class="btn btn-light" href="#">{{ offre.applications|length }} candidat{{ offre.applications|length > 1 ? 's' : '' }} ont posté leur candidature</a></p>
+                                    <p>
+                                        <a class="btn btn-light" href="#">{{ offre.applications|length }} candidat{{ offre.applications|length > 1 ? 's' : '' }} ont posté leur candidature</a>
+                                    </p>
+                                    <p class="small text-muted">Favoris : {{ favorisCounts[offre.id]|default(0) }}</p>
                                 </div>
                             </div>
                         </div>

--- a/templates/white_label/client1/user/annonce.html.twig
+++ b/templates/white_label/client1/user/annonce.html.twig
@@ -129,10 +129,22 @@
                                         <h4 class="section-head-small my-4">Résumé Olona Talents</h4>
                                         {{ jobOffer.shortDescription|raw }}
                                     {% endif %}
+                                    {% if favorisList is defined and favorisList|length > 0 %}
+                                        <h4 class="section-head-small my-4">Favoris</h4>
+                                        <ul class="list-unstyled">
+                                            {% for fav in favorisList %}
+                                                <li>
+                                                    <a href="{{ path('app_white_label_client1_recruiter_view_profile', {'id': fav.candidat.id}) }}">
+                                                        {{ fav.candidat.candidat.nom }} {{ fav.candidat.candidat.prenom }} - {{ fav.candidat.titre }}
+                                                    </a>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% endif %}
                                 </div>
                             </div>
-						</div>
-					</div>
+                                                </div>
+                                        </div>
 					<div class="advertisment" style="background-image:url({{ asset('v2/images/coworking-olona-talents.webp')}});">
 						<h4 class="title">Rejoignez BANK OF AFRICA</h4>
                         <p>VOUS VOULEZ UNE VIE PROFESSIONNELLE PASSIONNANTE<br>


### PR DESCRIPTION
## Summary
- show favorites count on recruiter job listing page
- list favorites on recruiter job view
- expose repository methods to count favorites

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677c9d68348330bf460f334ad2278d