### PR TITLE
Remove example-wrapper styles

### DIFF
--- a/templates/ajax/moderateur/index.html.twig
+++ b/templates/ajax/moderateur/index.html.twig
@@ -3,12 +3,8 @@
 {% block title %}Hello ModerateurController!{% endblock %}
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Hello {{ controller_name }}! ✅</h1>
 
     This friendly message is coming from:

--- a/templates/white_label/client1/admin/candidat/index.html.twig
+++ b/templates/white_label/client1/admin/candidat/index.html.twig
@@ -6,11 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Tous les candidats</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_candidat_profile_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/admin/candidature/index.html.twig
+++ b/templates/white_label/client1/admin/candidature/index.html.twig
@@ -6,11 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Tous les candidatures</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_application_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/admin/configuration.html.twig
+++ b/templates/white_label/client1/admin/configuration.html.twig
@@ -4,7 +4,7 @@
 {% block page_title %}Configuration{% endblock %}
 
 {% block body %}
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Configuration</h1>
     <a href="{{ path('app_white_label_client1_admin_csv_upload') }}" class="btn btn-secondary my-3">Importer un CV</a>
     <a href="{{ path('connect_google_drive') }}" class="btn btn-primary">Connecter Google Drive</a>

--- a/templates/white_label/client1/admin/csv_upload.html.twig
+++ b/templates/white_label/client1/admin/csv_upload.html.twig
@@ -5,12 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Importer un CV</h1>
     {{ form_start(form, {'attr': {'class': 'white-label-form'}})}}
     {{ form_widget(form)}}

--- a/templates/white_label/client1/admin/employe/index.html.twig
+++ b/templates/white_label/client1/admin/employe/index.html.twig
@@ -6,11 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Tous les coopteurs</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_employe_profile_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/admin/finance_employe/index.html.twig
+++ b/templates/white_label/client1/admin/finance_employe/index.html.twig
@@ -6,11 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Tous les employés</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_employe_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/admin/index.html.twig
+++ b/templates/white_label/client1/admin/index.html.twig
@@ -6,12 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Hello Admin! ✅</h1>
     <section class="visibility_p d-md-flex bp_ mb-4">
         <div class="biographie-profil mb-4 p-4 apparition_">

--- a/templates/white_label/client1/admin/job_listing/index.html.twig
+++ b/templates/white_label/client1/admin/job_listing/index.html.twig
@@ -5,11 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Gestion des annonces</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_job_listing_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/admin/recruiter/index.html.twig
+++ b/templates/white_label/client1/admin/recruiter/index.html.twig
@@ -6,11 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Tous les recruteurs</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_entreprise_profile_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/admin/user/index.html.twig
+++ b/templates/white_label/client1/admin/user/index.html.twig
@@ -6,11 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Tous les utilisateurs</h1>
     <div>
         <a class="btn btn-primary my-3 px-5 rounded-pill" href="{{ path('app_white_label_user_new') }}"><i class="bi me-2 bi-plus-lg"></i>Ajouter</a>

--- a/templates/white_label/client1/employe/profile.html.twig
+++ b/templates/white_label/client1/employe/profile.html.twig
@@ -5,7 +5,7 @@
 
 
 {% block body %}
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Mes infos</h1>
 </div>
 {% endblock %}

--- a/templates/white_label/client1/home/index.html.twig
+++ b/templates/white_label/client1/home/index.html.twig
@@ -5,11 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%;}
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Hello {{ user.prenom }}! 🙂</h1>
 </div>
 

--- a/templates/white_label/client1/recruiter/csv_upload.html.twig
+++ b/templates/white_label/client1/recruiter/csv_upload.html.twig
@@ -5,12 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Importer un CV</h1>
     {{ form_start(form, {'attr': {'class': 'white-label-form'}})}}
     {{ form_widget(form)}}

--- a/templates/white_label/client1/recruiter/index.html.twig
+++ b/templates/white_label/client1/recruiter/index.html.twig
@@ -6,12 +6,8 @@
 
 {% block body %}
 
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1>Hello {{ app.user.prenom }}! 🙂</h1>
     <section class="visibility_p d-md-flex bp_">
         <div class="biographie-profil mb-4 p-4 apparition_">

--- a/templates/white_label/client1/referrer/cooptation/references.html.twig
+++ b/templates/white_label/client1/referrer/cooptation/references.html.twig
@@ -5,12 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5;}
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 {% set defaultRewards = annonce.salaire / 10 %}
-<div class="example-wrapper">
+<div class="container mt-4">
             <h1 class="card-title h2 text-info">{{ annonce.titre }}</h1>
             <p class="text-muted small">
                 <i class="bi bi-circle-fill small mx-2 text-danger"></i> {{ getStatuses(annonce.status) }}  

--- a/templates/white_label/client1/referrer/references.html.twig
+++ b/templates/white_label/client1/referrer/references.html.twig
@@ -5,12 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5;}
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1 class="card-title mb-4">Mes cooptés</h1>
     {% if referrals|length > 0 %}
     <div class="container">

--- a/templates/white_label/client1/user/missions.html.twig
+++ b/templates/white_label/client1/user/missions.html.twig
@@ -5,12 +5,8 @@
 
 
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
 
-<div class="example-wrapper">
+<div class="container mt-4">
     <h1 class="card-title mb-4">Recrutement BOA</h1>
     <div class="container">
         <div class="row">


### PR DESCRIPTION
## Summary
- remove inline styles with `.example-wrapper`
- replace `.example-wrapper` containers with Bootstrap container markup

## Testing
- `php bin/phpunit` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867f7692fc08330838f7fa6c73a7e08