### PR TITLE
Update recruiter list with cooptation count

### DIFF
--- a/src/WhiteLabel/Controller/Client1/RecruiterController.php
+++ b/src/WhiteLabel/Controller/Client1/RecruiterController.php
@@ -165,7 +165,7 @@ class RecruiterController extends AbstractController
         }
 
         $page = $request->query->getInt('page', 1);
-        $status = $request->query->get('status', JobListing::STATUS_PUBLISHED);
+        $status = $request->query->get('status', 'ALL');
 
         $offres = $jobListingRepository->paginateJobListingsEntrepriseProfiles(
             $entreprise,
@@ -183,11 +183,14 @@ class RecruiterController extends AbstractController
         }
         $favorisCounts = $this->entityManager->getRepository(\App\WhiteLabel\Entity\Client1\Entreprise\Favoris::class)
             ->countByAnnonces($annonceIds);
+        $cooptationCounts = $this->entityManager->getRepository(\App\WhiteLabel\Entity\Client1\Referrer\Referral::class)
+            ->countByAnnonces($annonceIds);
 
         return $this->render('white_label/client1/recruiter/annonces.html.twig', [
             'entreprise' => $entreprise,
             'offres' => $offres,
             'favorisCounts' => $favorisCounts,
+            'cooptationCounts' => $cooptationCounts,
             'count' => $jobListingRepository->countAllByEntreprise($entreprise),
             'countStatus' => $jobListingRepository->countStatusByEntreprise($entreprise, $status),
             'statuses' => $jobListingManager->getStatuses(),

--- a/src/WhiteLabel/Entity/Client1/Entreprise/JobListing.php
+++ b/src/WhiteLabel/Entity/Client1/Entreprise/JobListing.php
@@ -67,6 +67,7 @@ class JobListing
 
     public static function getLabels() {
         return [
+            'ALL' =>        '<span class="badge bg-secondary">Toutes</span>' ,
              self::STATUS_DRAFT =>        '<span class="badge bg-info">Brouillon</span>' ,
              self::STATUS_PUBLISHED =>        '<span class="badge bg-success">Publiée</span>' ,
              self::STATUS_PENDING =>        '<span class="badge bg-warning">En attente</span>' ,

--- a/src/WhiteLabel/Manager/Client1/JobListingManager.php
+++ b/src/WhiteLabel/Manager/Client1/JobListingManager.php
@@ -121,6 +121,7 @@ class JobListingManager
     public function getStatuses(): array
     {
         return [
+            'Toutes' => 'ALL',
             'Publiée' => JobListing::STATUS_PUBLISHED ,
             'En attente' => JobListing::STATUS_PENDING ,
             'Expirée' => JobListing::STATUS_EXPIRED ,

--- a/src/WhiteLabel/Repository/Client1/Referrer/ReferralRepository.php
+++ b/src/WhiteLabel/Repository/Client1/Referrer/ReferralRepository.php
@@ -101,5 +101,31 @@ class ReferralRepository extends ServiceEntityRepository
         return $referralsByReferrer;
     }
 
+    /**
+     * @param int[] $annonceIds
+     * @return array<int,int> id => count
+     */
+    public function countByAnnonces(array $annonceIds): array
+    {
+        if (empty($annonceIds)) {
+            return [];
+        }
+
+        $results = $this->createQueryBuilder('r')
+            ->select('IDENTITY(r.annonce) AS annonceId, COUNT(r.id) AS referralCount')
+            ->andWhere('r.annonce IN (:annonces)')
+            ->setParameter('annonces', $annonceIds)
+            ->groupBy('r.annonce')
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($results as $row) {
+            $counts[$row['annonceId']] = (int) $row['referralCount'];
+        }
+
+        return $counts;
+    }
+
 
 }

--- a/templates/white_label/client1/recruiter/annonces.html.twig
+++ b/templates/white_label/client1/recruiter/annonces.html.twig
@@ -53,10 +53,17 @@
                                     </div>
                                 </div>
                                 <div class="col-lg-4 mt-4">
-                                    <p>
-                                        <a class="btn btn-light" href="#">{{ offre.applications|length }} candidat{{ offre.applications|length > 1 ? 's' : '' }} ont posté leur candidature</a>
-                                    </p>
-                                    <p class="small text-muted">Favoris : {{ favorisCounts[offre.id]|default(0) }}</p>
+                                    <div class="d-grid gap-2">
+                                        <a class="btn btn-light" href="{{ offre.applications|length > 0 ? path('app_white_label_client1_recruiter_candidatures') : '#' }}">
+                                            {{ offre.applications|length }} candidat{{ offre.applications|length > 1 ? 's' : '' }} ont posté leur candidature
+                                        </a>
+                                        <a class="btn btn-light" href="{{ favorisCounts[offre.id]|default(0) > 0 ? path('app_white_label_client1_recruiter_favoris') : '#' }}">
+                                            Favoris : {{ favorisCounts[offre.id]|default(0) }}
+                                        </a>
+                                        <a class="btn btn-light" href="{{ cooptationCounts[offre.id]|default(0) > 0 ? '#' : '#' }}">
+                                            Cooptations : {{ cooptationCounts[offre.id]|default(0) }}
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- show all recruiter job offers by default
- include option `Toutes` in filter select
- display number of cooptations per offer
- factor counts via repository helper

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*
- `npm run build` *(fails: encore not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fb3b0edc8330900df3383b8b7cce