### PR TITLE
Fix sidebar logo and recruiter wording

### DIFF
--- a/templates/white_label/client1/admin/candidat/new.html.twig
+++ b/templates/white_label/client1/admin/candidat/new.html.twig
@@ -8,7 +8,7 @@
 <section class="p-0 m-0">
     <div class="container">
         <div class="row p-4 pb-0 pe-lg-0 pt-lg-5 align-items-center">
-            <h1 class="h3">Créer un EntrepriseProfile</h1>
+            <h1 class="h3">Créer un recruteur</h1>
 
             {{ include('white_label/client1/admin/candidat/_form.html.twig') }}
         </div>

--- a/templates/white_label/client1/admin/recruiter/edit.html.twig
+++ b/templates/white_label/client1/admin/recruiter/edit.html.twig
@@ -8,7 +8,7 @@
 <section class="p-0 m-0">
     <div class="container">
         <div class="row p-4 pb-0 pe-lg-0 pt-lg-5 align-items-center">
-            <h1 class="h3">Edit EntrepriseProfile</h1>
+            <h1 class="h3">Modifier recruteur</h1>
 
             {{ include('white_label/client1/admin/recruiter/_form.html.twig', {'button_label': 'Update'}) }}
 

--- a/templates/white_label/client1/admin/recruiter/new.html.twig
+++ b/templates/white_label/client1/admin/recruiter/new.html.twig
@@ -8,7 +8,7 @@
 <section class="p-0 m-0">
     <div class="container">
         <div class="row p-4 pb-0 pe-lg-0 pt-lg-5 align-items-center">
-            <h1 class="h3">Créer un EntrepriseProfile</h1>
+            <h1 class="h3">Créer un recruteur</h1>
 
             {{ include('white_label/client1/admin/recruiter/_form.html.twig') }}
         </div>

--- a/templates/white_label/client1/home/annonce.html.twig
+++ b/templates/white_label/client1/home/annonce.html.twig
@@ -66,7 +66,7 @@
                                             <span class="view_title">{{ jobOffer.applications|length }} offres</span>
                                         </li>
                                     </ul>
-                                    <h4 class="section-head-small mb-4">Entreprise</h4>
+                                    <h4 class="section-head-small mb-4">Recruteur</h4>
                                     <a href="#">{{ jobOffer.entreprise.nom }}</a>
                                     {% if jobOffer.shortDescription is not null %}
                                         <h4 class="section-head-small my-4">Résumé Olona Talents</h4>

--- a/templates/white_label/client1/layout/sidebar.html.twig
+++ b/templates/white_label/client1/layout/sidebar.html.twig
@@ -2,8 +2,8 @@
 {% set current_route = app.request.attributes.get('_route') %}
 <div class="sidebar-area bg-white">
 	<div class="logo-brand d-flex justify-content-between align-items-center">
-	<a class="navbar-brand" href="{{ path('app_white_label_home') }}">
-		<img id="logo" src="{{ asset('images/white-label/Bank_of_africa-logo.png') }}" width="150" height="56" class="" alt="Logo">
+        <a class="navbar-brand" href="{{ path('app_white_label_home') }}">
+                <img id="logo" src="{{ asset('images/white-label/Bank_of_africa-logo.png') }}" width="150" class="" alt="Logo">
 	</a>
 	<button id="menuIcon" class="menu-icon" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasScrolling" aria-controls="offcanvasScrolling" aria-expanded="false" aria-label="Toggle navigation">
 		<span></span>

--- a/templates/white_label/client1/user/index.html.twig
+++ b/templates/white_label/client1/user/index.html.twig
@@ -52,7 +52,7 @@
             </div>
         {% elseif entreprise is defined %}
             <div class="biographie-profil mb-4 p-4">
-                <span class="fs-5 fw-bold mb-3 lh-base st-title">Profil entreprise</span>
+                <span class="fs-5 fw-bold mb-3 lh-base st-title">Profil recruteur</span>
                 <div class="d-md-flex flex-box_">
                     <span class="fs-6 lh-base">Nom</span>
                     <div class="d-md-flex fw-bold info-bx flex-box_">


### PR DESCRIPTION
## Summary
- adjust logo markup in sidebar
- update recruiter templates to remove EntrepriseProfile wording
- switch "Entreprise" heading to "Recruteur"
- rename "Profil entreprise" section to "Profil recruteur"

## Testing
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680a7877c08330a2d14f2424d0a2eb